### PR TITLE
Remove usages of IsTaggedByAllThreatLists

### DIFF
--- a/Quest Behaviors/QuestBehaviorCore/Extensions/Extensions_WoWUnit.cs
+++ b/Quest Behaviors/QuestBehaviorCore/Extensions/Extensions_WoWUnit.cs
@@ -60,7 +60,7 @@ namespace Honorbuddy.QuestBehaviorCore
 				165962,		// Druid: Flight Form (Patch 6.0.2)
 				33943,      // Druid: Flight Form
 				40120,      // Druid: Swift Flight Form
-				  783,      // Druid: Travel Form       
+				  783,      // Druid: Travel Form
 				93326,      // Herbalist: Sandstone Drake
 				 2645,      // Shaman: Ghost Wolf
 				87840,      // Worgen: Running Wild
@@ -71,9 +71,7 @@ namespace Honorbuddy.QuestBehaviorCore
         public static bool IsUntagged(this WoWUnit wowUnit)
         {
             return (wowUnit != null)
-                && (wowUnit.TappedByAllThreatLists
-                    || wowUnit.TaggedByMe
-                    || !wowUnit.TaggedByOther);
+                && (wowUnit.TaggedByMe || !wowUnit.TaggedByOther);
         }
     }
 }

--- a/Quest Behaviors/QuestBehaviorCore/Utility/Query.cs
+++ b/Quest Behaviors/QuestBehaviorCore/Utility/Query.cs
@@ -53,10 +53,10 @@ namespace Honorbuddy.QuestBehaviorCore
         public static bool AtLocation(WoWPoint myLoc, WoWPoint location, float? tolerance)
         {
             var tol = tolerance ?? Navigator.PathPrecision;
-            // We are checking if point is in an upright cylinder whose center is positioned at 'location', 
+            // We are checking if point is in an upright cylinder whose center is positioned at 'location',
             // radius set to 'tolerance' and height set to max(4.5, 'tolerance') x 2.
-            // This is the most suitable method when using mesh navigation because the mesh is often above or below the 
-            // actual ingame terrain so there's a need to clamp the tolerance along the Z axis to an amount that 
+            // This is the most suitable method when using mesh navigation because the mesh is often above or below the
+            // actual ingame terrain so there's a need to clamp the tolerance along the Z axis to an amount that
             // is greater then the maximum terrain/mesh Z coord difference
             return myLoc.Distance2DSqr(location) <= tol * tol && Math.Abs(myLoc.Z - location.Z) <= Math.Max(4.5f, tol);
         }
@@ -312,9 +312,9 @@ namespace Honorbuddy.QuestBehaviorCore
             { return false; }
 
             // If unit is tagged by someone else and in combat, it is in competition...
-            // N.B. There are some cases where NPCs are shown as tagged by - 
-            // someone else yet nobody is actively engaged with said unit. 
-            // If unit is not in combat with anyone and it is tagged and nobody else is around it can not be in competition. 
+            // N.B. There are some cases where NPCs are shown as tagged by -
+            // someone else yet nobody is actively engaged with said unit.
+            // If unit is not in combat with anyone and it is tagged and nobody else is around it can not be in competition.
             // On the other hand if we choose to ignore the tagged unit and it's the only NPC that exists in the world then bot will be stuck
             var wowUnit = wowObject as WoWUnit;
             var isTaggedByOther = ((wowUnit != null) && !wowUnit.IsUntagged() && wowUnit.Combat);
@@ -570,7 +570,7 @@ namespace Honorbuddy.QuestBehaviorCore
             var wowUnit = wowObject as WoWUnit;
 
             isSharedResource |= (wowGameObject != null) && s_sharedGameObjectTypes.Contains(wowGameObject.SubType);
-            isSharedResource |= (wowUnit != null) && wowUnit.TappedByAllThreatLists;
+            isSharedResource |= (wowUnit != null) && !wowUnit.TaggedByOther;
             isSharedResource |= (wowUnit != null) && !wowUnit.IsHostile
                                 && (wowUnit.IsAnyTrainer
                                     || wowUnit.IsAnyVendor
@@ -682,7 +682,7 @@ namespace Honorbuddy.QuestBehaviorCore
 
         /// <summary>
         /// <p>Returns 'true' if WOWOBJECT is located in a blackspot; otherwise, 'false'.</p>
-        /// 
+        ///
         /// <p>Not all blackspots are created equal.  For targeting purposes, we only want to consider
         /// blackspots defined by the profile (static), or the QBcore-based behaviors (a subset of dynamic
         /// blackspots).  Other blackspots, such as those dropped by the StuckHandler (also dynamic), should not

--- a/Quest Behaviors/SpecificQuests/14382-Gilneas-TwoBySea.cs
+++ b/Quest Behaviors/SpecificQuests/14382-Gilneas-TwoBySea.cs
@@ -18,7 +18,7 @@
 //  4) Exits the boat by 'jumping down'
 //  5) Repeats the above steps for both Captain Anson and Captain Morris
 //  6) Profit!
-// 
+//
 // THINGS TO KNOW:
 // * If for any reason, we lose the Catapult, another one will be acquired
 // * If for any reason we miss boarding the boat with the Catapult,
@@ -646,7 +646,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.TwoBySea
                     unit.IsValid
                     && unit.IsAlive
                     && unitIds.Contains((int)unit.Entry)
-                    && (unit.TappedByAllThreatLists || !unit.TaggedByOther)
+                    && !unit.TaggedByOther
                 select unit;
         }
 

--- a/Quest Behaviors/SpecificQuests/14395-Gilneas-GaspingForBreath.cs
+++ b/Quest Behaviors/SpecificQuests/14395-Gilneas-GaspingForBreath.cs
@@ -618,7 +618,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.GaspingForBreath
                     unit.IsValid
                     && unit.IsAlive
                     && unitIds.Contains((int)unit.Entry)
-                    && (unit.TappedByAllThreatLists || !unit.TaggedByOther)
+                    && !unit.TaggedByOther
                 select unit;
         }
 

--- a/Quest Behaviors/SpecificQuests/27738-Uldum-ThePitOfScales.cs
+++ b/Quest Behaviors/SpecificQuests/27738-Uldum-ThePitOfScales.cs
@@ -645,7 +645,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.ThePitOfScales
                     unit.IsValid
                     && unit.IsAlive
                     && unitIds.Contains((int)unit.Entry)
-                    && (unit.TappedByAllThreatLists || !unit.TaggedByOther)
+                    && !unit.TaggedByOther
                 select unit;
         }
 

--- a/Quest Behaviors/SpecificQuests/30690-KunLai-UnmaskingTheYaungol.cs
+++ b/Quest Behaviors/SpecificQuests/30690-KunLai-UnmaskingTheYaungol.cs
@@ -21,7 +21,7 @@
 //  5) Steal Kobai's mask
 //  6) Reprioritizes kill target to Malevolent Fury when it arrives
 //  7) Profit!
-// 
+//
 // THINGS TO KNOW:
 //  * If the event fails for some reason, the event retries automatically.
 //
@@ -31,7 +31,7 @@
 //      the trap placement and mask pilfering (i.e., Shaman's "Feral Spirit").
 //      There is a safety measure if the toon's health gets below 60%
 //      while waiting to pilfer the mask, it will start defending itself.
-//      If this happens, the event is automatically retried. 
+//      If this happens, the event is automatically retried.
 //      "Not defending" also prevents failures if the class max level
 //      is ever increased above 90 by Blizzard, or the toon is uber-geared.
 //
@@ -164,7 +164,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UnmaskingTheYaungol
                 return
                     from unit in ObjectManager.GetObjectsOfType<WoWUnit>(true, false)
                     where (unit.Entry == unitId) && unit.IsAlive
-                            && (unit.TaggedByMe || unit.TappedByAllThreatLists || !unit.TaggedByOther)
+                            && unit.IsUntagged()
                     select unit;
             }
         }

--- a/Quest Behaviors/SpecificQuests/30978-TownlongSteppes-HostileSkies.cs
+++ b/Quest Behaviors/SpecificQuests/30978-TownlongSteppes-HostileSkies.cs
@@ -17,7 +17,7 @@
 //      Killing the Voress'thalik will be preferred over Korthik Swarmers
 //      anytime it is up.
 //  3) Profit!
-// 
+//
 // THINGS TO KNOW:
 // * We completely disable combat for this behavior
 //      Combat is unnecessary while in this vehicle, and it allows
@@ -380,7 +380,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.HostileSkies
                     unit.IsValid
                     && unit.IsAlive
                     && (unit.Entry == unitId)
-                    && (unit.TaggedByMe || unit.TappedByAllThreatLists || !unit.TaggedByOther)
+                    && unit.IsUntagged()
                 select unit;
         }
 

--- a/Quest Behaviors/SpecificQuests/30991-KunLai-DoABarrelRoll.cs
+++ b/Quest Behaviors/SpecificQuests/30991-KunLai-DoABarrelRoll.cs
@@ -17,7 +17,7 @@
 //      Some Osul Invaders will be collateral damage, and this saves us time
 //  3) Takes out the requird Osul Treelaunchers & Osul Invaders
 //  4) Profit!
-// 
+//
 // THINGS TO KNOW:
 // * Exit Vehicle doesn't work for this quest
 //      You must blow up the vehicle to exit
@@ -186,7 +186,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.DoABarrelRoll
                 return
                     from unit in ObjectManager.GetObjectsOfType<WoWUnit>(true, false)
                     where (unit.Entry == unitId) && unit.IsAlive
-                            && (unit.TaggedByMe || unit.TappedByAllThreatLists || !unit.TaggedByOther)
+                            && unit.IsUntagged()
                     select unit;
             }
         }


### PR DESCRIPTION
This was removed from WoW, and we don't really need it.
