### PR TITLE
Fix Git ID to Version ID conversion

### DIFF
--- a/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
+++ b/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
@@ -364,11 +364,11 @@ namespace Honorbuddy.QuestBehaviorCore
 
         internal static string GitIdToVersionId(string str)
         {
-            // Format: $Id$
-            if (str == "$Id$") // Unexpanded, probably by downloading directly or something
+            // Format is $ Id$, without the space, when unexpanded
+            if (str == "$" + "Id$") // Unexpanded, probably by downloading directly or something
                 return "vUnk";
 
-            return str.Substring(4, 6);
+            return str.Substring(5, 6);
         }
 
         #endregion


### PR DESCRIPTION
- The check to see if they were unexpanded used $Id$ and was itself
  expanded. Rewrite this in a way where it does not get expanded.
- The actual conversion did not assume there would would be whitespace
  around the ID. Take this into account.
