### PR TITLE
KUC no longer goes for new NPCs immediately

### DIFF
--- a/Quest Behaviors/KillUntilComplete.cs
+++ b/Quest Behaviors/KillUntilComplete.cs
@@ -256,8 +256,13 @@ namespace Honorbuddy.Quest_Behaviors.KillUntilComplete
 
         private async Task<bool> Coroutine_CombatMain()
         {
-            if (!_targetSwitchTimer.IsFinished || BotPoi.Current.Type != PoiType.Kill || !ImmediatelySwitchToHighestPriorityTarget || !Me.Combat)
-                return false;
+	        if (!ImmediatelySwitchToHighestPriorityTarget || !_targetSwitchTimer.IsFinished || 
+				BotPoi.Current.Type != PoiType.Kill || !Me.Combat || 
+				// Let quest bot handle targeting when we don't have any targets. High priority targets will be picked first as they are weighted more in targeting.
+				// Otherwise, there is a race condition happens where we immediately pick a new target when current one dies and we are still in combat for split second. 
+				// This was causing the looting etc. to be skipped
+				Me.CurrentTarget == null || Me.CurrentTarget.IsDead)
+		        return false;
 
             var firstUnit = Targeting.Instance.FirstUnit;
             if (!Query.IsViable(firstUnit))


### PR DESCRIPTION
This would cause it to skip loots.
# HB-2830 Fixed Changelog KillUntilComplete will no longer keep going after

new NPCs immediately which has caused skipping loots.
