### PR TITLE
Remove MountHook on bot stop or profile load

### DIFF
--- a/Quest Behaviors/Hooks/MountHook.cs
+++ b/Quest Behaviors/Hooks/MountHook.cs
@@ -151,10 +151,13 @@ namespace Honorbuddy.Quest_Behaviors.Hooks
         {
             OnStart_HandleAttributeProblem();
 
-            if (_state == true)
+            if (_state)
             {
                 if (_myHook == null)
                 {
+                    BotEvents.OnBotStopped += BotEvents_OnBotStopped;
+                    BotEvents.Profile.OnNewProfileLoaded += Profile_OnNewProfileLoaded;
+
                     QBCLog.Info("Inserting hook");
                     _myHook = CreateHook();
                     TreeHooks.Instance.InsertHook("Questbot_Profile", 0, _myHook);
@@ -166,19 +169,36 @@ namespace Honorbuddy.Quest_Behaviors.Hooks
             }
             else
             {
-                if (_myHook != null)
-                {
-                    QBCLog.Info("Removing hook");
-                    TreeHooks.Instance.RemoveHook("Questbot_Profile", _myHook);
-                    _myHook = null;
-                }
-                else
+                if (!RemoveHook())
                 {
                     QBCLog.Info("Remove was requested, but hook was not present");
                 }
             }
         }
 
+        private bool RemoveHook()
+        {
+            if (_myHook == null)
+                return false;
+
+            QBCLog.Info("Removing hook");
+            TreeHooks.Instance.RemoveHook("Questbot_Profile", _myHook);
+
+            BotEvents.OnBotStopped -= BotEvents_OnBotStopped;
+            BotEvents.Profile.OnNewProfileLoaded -= Profile_OnNewProfileLoaded;
+            _myHook = null;
+            return true;
+        }
+
+        private void Profile_OnNewProfileLoaded(BotEvents.Profile.NewProfileLoadedEventArgs args)
+        {
+            RemoveHook();
+        }
+
+        private void BotEvents_OnBotStopped(EventArgs args)
+        {
+            RemoveHook();
+        }
 
         public static Composite _myHook;
         public Composite CreateHook()

--- a/Quest Behaviors/KillUntilComplete.cs
+++ b/Quest Behaviors/KillUntilComplete.cs
@@ -256,13 +256,13 @@ namespace Honorbuddy.Quest_Behaviors.KillUntilComplete
 
         private async Task<bool> Coroutine_CombatMain()
         {
-	        if (!ImmediatelySwitchToHighestPriorityTarget || !_targetSwitchTimer.IsFinished || 
-				BotPoi.Current.Type != PoiType.Kill || !Me.Combat || 
-				// Let quest bot handle targeting when we don't have any targets. High priority targets will be picked first as they are weighted more in targeting.
-				// Otherwise, there is a race condition happens where we immediately pick a new target when current one dies and we are still in combat for split second. 
-				// This was causing the looting etc. to be skipped
-				Me.CurrentTarget == null || Me.CurrentTarget.IsDead)
-		        return false;
+            if (!ImmediatelySwitchToHighestPriorityTarget || !_targetSwitchTimer.IsFinished ||
+                BotPoi.Current.Type != PoiType.Kill || !Me.Combat ||
+                // Let quest bot handle targeting when we don't have any targets. High priority targets will be picked first as they are weighted more in targeting.
+                // Otherwise, there is a race condition happens where we immediately pick a new target when current one dies and we are still in combat for split second.
+                // This was causing the looting etc. to be skipped
+                Me.CurrentTarget == null || Me.CurrentTarget.IsDead)
+                return false;
 
             var firstUnit = Targeting.Instance.FirstUnit;
             if (!Query.IsViable(firstUnit))


### PR DESCRIPTION
# HB-2832 Fixed Changelog MountHook will now be removed when the bot is stopped or a new profile is loaded.
