### PR TITLE
Add a default for QuestBehaviorBase.GitId

### DIFF
--- a/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
+++ b/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
@@ -358,7 +358,10 @@ namespace Honorbuddy.QuestBehaviorCore
 
         public readonly Stopwatch _behaviorRunTimer = new Stopwatch();
 
-        protected abstract string GitId { get; }
+        // For the default value we use unexpanded
+        // Git ID which GitIdToVersionId handles to
+        // return vUnk.
+        protected virtual string GitId => "$" + "Id";
 
         public override string VersionId => GitIdToVersionId(GitId);
 


### PR DESCRIPTION
This must be considered public API even though it depends completely on compilation order whether 3rd party devs can use it.
