### PR TITLE
Improve mounting/dismounting logic after HB3 fixes

### DIFF
--- a/Quest Behaviors/ForcedDismount.cs
+++ b/Quest Behaviors/ForcedDismount.cs
@@ -152,10 +152,10 @@ namespace Honorbuddy.Quest_Behaviors.ForcedDismount
         {
             return new PrioritySelector(
                 // If we're not mounted, nothing to do...
-                new Decorator(ret => !Me.IsMounted() && !Me.IsShapeshifted(),
+                new Decorator(ret => !Me.Mounted,
                     new Action(delegate { BehaviorDone(); })),
 
-                new ActionRunCoroutine(context => UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.DismountOrCancelShapeshift))
+                new ActionRunCoroutine(context => UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.Dismount))
             );
         }
         #endregion

--- a/Quest Behaviors/Hooks/DoWhen.cs
+++ b/Quest Behaviors/Hooks/DoWhen.cs
@@ -994,7 +994,7 @@ namespace Honorbuddy.Quest_Behaviors.DoWhen
                     && (AllowUseDuringCombat || !Me.Combat)
                     && (AllowUseInVehicle || !Query.IsInVehicle())
                     && (AllowUseWhileFlying || !Me.IsFlying)
-                    && (AllowUseWhileMounted || !Me.IsMounted());
+                    && (AllowUseWhileMounted || !Me.Mounted);
             }
         }
 

--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -156,18 +156,13 @@
 //          If the toon is too close to the mob, the toon will move to acquire this minimum
 //          distance to the mob.
 //      PreInteractMountStrategy [optional; Default: None]
-//          [allowed values: CancelShapeshift, Dismount, DismountOrCancelShapeshift, Mount, None]
+//          [allowed values: Dismount, Mount, None]
 //          Provides the opportunity to alter the mounting state of a toon immediately prior
 //          to interacting, or using an object.  The options are defined as follows:
-//              CancelShapeshift
-//                  Cancels *any* shapeshifted form, whether it represents a 'mounted form'
-//                  or not.  Examples of non-mounted forms include a Druid's Bear or Cat Form.
 //              Dismount
 //                  Unmounts from an explicit mount, or cancels a 'mounted form'.  Examples
 //                  of mounted forms are Druid Flight Forms, Druid Travel Form, Shaman Ghost Wolf,
 //                  and Worgen Running Wild.
-//              DismountOrCancelShapeshift
-//                  Dismounts or cancel's a shapeshifted form--whichever is appropriate.
 //              Mount
 //                  Mounts the mount defined in the user's preference settings.
 //              None

--- a/Quest Behaviors/Misc/BreakImmunityByKillingMobsInCloseProximity.cs
+++ b/Quest Behaviors/Misc/BreakImmunityByKillingMobsInCloseProximity.cs
@@ -201,7 +201,7 @@ namespace Honorbuddy.Quest_Behaviors.BreakImmunityByKillingMobsInCloseProximity
                 // Dismount after reaching search location.
                 else if ((SearchLocation == Vector3.Zero || Navigator.AtLocation(SearchLocation)) && Me.Mounted)
                 {
-                    await UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.DismountOrCancelShapeshift);
+                    await UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.Dismount);
                 }
                 else
                 {

--- a/Quest Behaviors/MyCTM.cs
+++ b/Quest Behaviors/MyCTM.cs
@@ -274,7 +274,7 @@ namespace Honorbuddy.Quest_Behaviors.MyCTM
                         // Check if stuck...
                         new DecoratorContinue(context => _antiStuckMyLoc.DistanceSquared(_antiStuckPrevPosition) < (3 * 3),
                             new Sequence(context => _antiStuckPerformSimpleSequence = _antiStuckStuckSucceedTimer.IsFinished,
-                                new DecoratorContinue(context => Me.IsMounted() && !Me.IsFlying,
+                                new DecoratorContinue(context => Me.Mounted && !Me.IsFlying,
                                     new ActionRunCoroutine(context => CommonCoroutines.Dismount("Stuck"))),
 
                                 // Perform simple unstuck proceedure...

--- a/Quest Behaviors/QuestBehaviorCore/Extensions/Extensions_WoWUnit.cs
+++ b/Quest Behaviors/QuestBehaviorCore/Extensions/Extensions_WoWUnit.cs
@@ -20,53 +20,6 @@ namespace Honorbuddy.QuestBehaviorCore
 {
     public static class Extensions_WoWUnit
     {
-        /// <summary>
-        /// Similar to WoWUnit.Mounted, but also tests for auras that provide a 'mounted' characteristic.
-        /// <para>Notes:<list type="bullet">
-        /// <item><description><para> * The following auras count as 'mounted' auras:
-        /// Druid(Flight Form), Druid(Swift Fight Form), Druid(Travel Form), Shaman(Ghost Wolf),
-        /// Worgen(Running Wild).</para></description></item>
-        /// </list></para>
-        /// </summary>
-        /// <param name="wowUnit"></param>
-        /// <returns></returns>
-        public static bool IsMounted(this WoWUnit wowUnit)
-        {
-            return (wowUnit.Mounted
-                    || wowUnit.GetAllAuras().Any(a => s_mountedAuras.Contains(a.SpellId)));
-        }
-        private readonly static int[] s_mountedAuras =
-            {
-                165962,		// Druid: Flight Form (Patch 6.0.2)
-				33943,      // Druid: Flight Form
-				40120,      // Druid: Swift Flight Form
-				  783,      // Druid: Travel Form
-				93326,      // Herbalist: Sandstone Drake
-				 2645,      // Shaman: Ghost Wolf
-				87840,      // Worgen: Running Wild
-			};
-
-
-        // 16Apr2013-10:34UTC chinajade
-        public static bool IsShapeshifted(this WoWUnit wowUnit)
-        {
-            return wowUnit.GetAllAuras().Any(a => s_shapeshiftAuras.Contains(a.SpellId));
-        }
-        private readonly static int[] s_shapeshiftAuras =
-            {
-                 1066,      // Druid: Aquatic Form
-				 5487,      // Druid: Bear Form
-				  768,      // Druid: Cat Form
-				165962,		// Druid: Flight Form (Patch 6.0.2)
-				33943,      // Druid: Flight Form
-				40120,      // Druid: Swift Flight Form
-				  783,      // Druid: Travel Form
-				93326,      // Herbalist: Sandstone Drake
-				 2645,      // Shaman: Ghost Wolf
-				87840,      // Worgen: Running Wild
-			};
-
-
         // 11Apr2013-07:48UTC chinajade
         public static bool IsUntagged(this WoWUnit wowUnit)
         {

--- a/Quest Behaviors/QuestBehaviorCore/Types.cs
+++ b/Quest Behaviors/QuestBehaviorCore/Types.cs
@@ -102,7 +102,11 @@ namespace Honorbuddy.QuestBehaviorCore
 
     public enum MountStrategyType
     {
+        [Obsolete("Use Dismount instead. This will be removed in the future.")]
+        CancelShapeshift,
         Dismount,
+        [Obsolete("Use Dismount instead. This will be removed in the future.")]
+        DismountOrCancelShapeshift,
         Mount,
         None,
     }

--- a/Quest Behaviors/QuestBehaviorCore/Types.cs
+++ b/Quest Behaviors/QuestBehaviorCore/Types.cs
@@ -63,7 +63,7 @@ namespace Honorbuddy.QuestBehaviorCore
         Vehicle,
 
         /// <summary>
-        ///     The ability is an area of effect that is centered on the caster and radiates out in every direction (360 degrees) 
+        ///     The ability is an area of effect that is centered on the caster and radiates out in every direction (360 degrees)
         ///		e.g. Thunder Clap
         /// </summary>
         PointBlankAreaOfEffect,
@@ -102,9 +102,7 @@ namespace Honorbuddy.QuestBehaviorCore
 
     public enum MountStrategyType
     {
-        CancelShapeshift,
         Dismount,
-        DismountOrCancelShapeshift,
         Mount,
         None,
     }
@@ -187,7 +185,7 @@ namespace Honorbuddy.QuestBehaviorCore
         public ContractException(string message = null)
             : base(message ?? string.Empty)
         {
-            // empty   
+            // empty
         }
     }
 }

--- a/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Mount.cs
+++ b/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Mount.cs
@@ -45,14 +45,18 @@ namespace Honorbuddy.QuestBehaviorCore
                 return false;
             }
 
+#pragma warning disable 618
             // Dismount needed?
-            if (mountStrategy == MountStrategyType.Dismount)
+            if (mountStrategy == MountStrategyType.Dismount ||
+                mountStrategy == MountStrategyType.CancelShapeshift ||
+                mountStrategy == MountStrategyType.DismountOrCancelShapeshift)
             {
                 if (!Me.Mounted)
                     return false;
 
                 return await CommonCoroutines.LandAndDismount("Requested by QB");
             }
+#pragma warning restore 618
 
             if (mountStrategy == MountStrategyType.Mount && Mount.UseMount && Mount.CanMount())
             {

--- a/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Mount.cs
+++ b/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Mount.cs
@@ -22,14 +22,6 @@ namespace Honorbuddy.QuestBehaviorCore
         ///             <item>
         ///                 <description>
         ///                     <para>
-        ///                         * A "CancelShapeshift" will cancel _any_ shapeshift form whether or not
-        ///                         that form represents a 'mounted' form or not.
-        ///                     </para>
-        ///                 </description>
-        ///             </item>
-        ///             <item>
-        ///                 <description>
-        ///                     <para>
         ///                         * A "Dismount" will unmount, or cancel a 'mounted' shapeshift form.
         ///                         Examples of the latter include: Druid Flight Form, Druid Travel Form, Shaman Ghost Wolf, Worgen
         ///                         Running Wild.
@@ -53,74 +45,45 @@ namespace Honorbuddy.QuestBehaviorCore
                 return false;
             }
 
-            // Cancel Shapeshift needed?
-            if (((mountStrategy == MountStrategyType.CancelShapeshift)
-                || (mountStrategy == MountStrategyType.DismountOrCancelShapeshift))
-                && Me.IsShapeshifted())
-            {
-                if (WoWMovement.ActiveMover.IsFlying)
-                {
-                    return await LandAndDismount();
-                }
-                TreeRoot.StatusText = "Canceling shapeshift form.";
-                Lua.DoString("CancelShapeshiftForm()");
-                return true;
-            }
-
             // Dismount needed?
-            if (((mountStrategy == MountStrategyType.Dismount)
-                || (mountStrategy == MountStrategyType.DismountOrCancelShapeshift))
-                && Me.IsMounted())
+            if (mountStrategy == MountStrategyType.Dismount)
             {
-                if (WoWMovement.ActiveMover.IsFlying)
-                {
-                    return await LandAndDismount();
-                }
-                if (Me.IsShapeshifted())
-                {
-                    TreeRoot.StatusText = "Canceling 'mounted' shapeshift form.";
-                    Lua.DoString("CancelShapeshiftForm()");
-                    return true;
-                }
-                if (Me.IsMounted())
-                {
-                    TreeRoot.StatusText = "Dismounting";
-
-                    // Mount.Dismount() uses the Flightor landing system, which sometimes get stuck
-                    // a yard or two above the landing zone...
-                    // So, we opt to dismount via LUA since we've controlled the landing ourselves.
-                    Lua.DoString("Dismount()");
-                    return true;
-                }
-            }
-
-            if ((mountStrategy == MountStrategyType.Mount) && Mount.UseMount)
-            {
-                // Flying and Ground mounts...
-                if (!WoWMovement.ActiveMover.IsSwimming)
-                {
-                    // If flying mount is wanted, and we're not on flying mount...
-                    if (navType == NavType.Fly && !Flightor.MountHelper.Mounted && Flightor.MountHelper.CanMount)
-                    {
-                        Flightor.MountHelper.MountUp();
-                        return true;
-                    }
-                    // Try ground mount...
-                    // NB: Force mounting by specifying a large distance to destination...
-                    if (!Me.Mounted && Mount.CanMount())
-                    {
-                        if (await CommonCoroutines.SummonGroundMount())
-                        {
-                            return true;
-                        }
-                    }
-                }
-                else
-                {
-                    // Swimming mounts...
+                if (!Me.Mounted)
                     return false;
-                }
+
+                return await CommonCoroutines.LandAndDismount("Requested by QB");
             }
+
+            if (mountStrategy == MountStrategyType.Mount && Mount.UseMount && Mount.CanMount())
+            {
+                if (Me.Mounted)
+                {
+                    // Check if we should switch mounts
+                    if (navType == NavType.Fly)
+                    {
+                        if (Mount.Current.IsFlyingMount || !Flightor.IsFlyableArea())
+                            return false;
+
+                        await CommonCoroutines.LandAndDismount("Switching to flying mount");
+                    }
+                    else
+                    {
+                        // If ground nav then any mount is fine.
+                        return false;
+                    }
+                }
+
+                if (navType == NavType.Fly)
+                {
+                    if (!Flightor.CanFly)
+                        return false;
+
+                    return await CommonCoroutines.SummonFlyingMount();
+                }
+
+                return await CommonCoroutines.SummonGroundMount();
+            }
+
             return false;
         }
 

--- a/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Movement.cs
+++ b/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Movement.cs
@@ -128,7 +128,7 @@ namespace Honorbuddy.QuestBehaviorCore
         private static async Task<bool> SetMountState(Vector3 destination, NavType navType = NavType.Fly)
         {
             // Are we mounted, and not supposed to be?
-            if (!Mount.UseMount && Me.IsMounted())
+            if (!Mount.UseMount && Me.Mounted)
             {
                 if (await ExecuteMountStrategy(MountStrategyType.Dismount))
                     return true;

--- a/Quest Behaviors/SpecificQuests/10129-10146-Hellfire-MurkethAndShaadraz.cs
+++ b/Quest Behaviors/SpecificQuests/10129-10146-Hellfire-MurkethAndShaadraz.cs
@@ -228,7 +228,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.MurkethAndShaadraz
                                             FlightMaster.SafeName,
                                             MovementBy))),
                                 new ActionRunCoroutine(context => CommonCoroutines.StopMoving()),
-                                 new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
+                                 new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
                                 new Decorator(context => !GossipFrame.Instance.IsVisible,
                                     new Action(context => { FlightMaster.Interact(); })),
                                 new Action(context => { GossipFrame.Instance.SelectGossipOption(0); })

--- a/Quest Behaviors/SpecificQuests/10162-10163-Hellfire-MissionTheAbyssalShelf.cs
+++ b/Quest Behaviors/SpecificQuests/10162-10163-Hellfire-MissionTheAbyssalShelf.cs
@@ -233,7 +233,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.MissionTheAbyssalShelf
                                             FlightMaster.SafeName,
                                             MovementBy))),
                                 new ActionRunCoroutine(context => CommonCoroutines.StopMoving()),
-                                new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
+                                new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
                                 new Decorator(context => !GossipFrame.Instance.IsVisible,
                                     new Action(context => { FlightMaster.Interact(); })),
                                 new Action(context => { GossipFrame.Instance.SelectGossipOption(GossipOption); })

--- a/Quest Behaviors/SpecificQuests/12259-GrizzlyHills-HordeTheThaneofVoldrune.cs
+++ b/Quest Behaviors/SpecificQuests/12259-GrizzlyHills-HordeTheThaneofVoldrune.cs
@@ -10,7 +10,7 @@
 //
 
 #region Summary and Documentation
-// This behavior is for killing Thane noobface in Grizzly Hills (Horde 12259 and Alliance 12255) 
+// This behavior is for killing Thane noobface in Grizzly Hills (Horde 12259 and Alliance 12255)
 // Code was taken from Shak
 #endregion
 
@@ -111,8 +111,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AllyTheThaneofVoldrune
                     new Decorator(ctx => flamebringer == null, CreateBehavior_MoveTo(ctx => _flamebringerLocation)),
                     new Decorator(ctx => flamebringer.Distance > 5, CreateBehavior_MoveTo(ctx => flamebringer.Location)),
                     // dismount and cancel shapeshift
-                    new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(context => CommonCoroutines.Dismount("Getting on Flamebringger"))),
-                    new Decorator(ctx => Me.IsShapeshifted(), new Action(ctx => Lua.DoString("CancelShapeshiftForm()"))),
+                    new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(context => CommonCoroutines.Dismount("Getting on Flamebringger"))),
                     new Decorator(ctx => Me.IsMoving, new Action(ctx => WoWMovement.MoveStop())),
                     // interact with and talk to flamebringer
                     new Decorator(ctx => !GossipFrame.Instance.IsVisible, new Action(ctx => flamebringer.Interact())),
@@ -155,7 +154,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AllyTheThaneofVoldrune
                             new Decorator(
                                 ctx => WoWMovement.ActiveMover.CurrentTargetGuid != torvaldEriksson.Guid,
                                 new Action(ctx => torvaldEriksson.Target())),
-                            // face 
+                            // face
                             new Decorator(
                                 ctx => !WoWMovement.ActiveMover.IsSafelyFacing(torvaldEriksson, 30),
                                 new Action(ctx => torvaldEriksson.Face())),

--- a/Quest Behaviors/SpecificQuests/24910-Tanaris-RocketRescue.cs
+++ b/Quest Behaviors/SpecificQuests/24910-Tanaris-RocketRescue.cs
@@ -308,8 +308,7 @@ namespace Honorbuddy.Quest_Behaviors.Tanaris.RocketRescue_24910
             if (Me.IsMoving)
                 await CommonCoroutines.StopMoving();
 
-            if (Me.Mounted && await UtilityCoroutine.ExecuteMountStrategy(
-                MountStrategyType.DismountOrCancelShapeshift))
+            if (Me.Mounted && await UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.Dismount))
             {
                 return true;
             }

--- a/Quest Behaviors/SpecificQuests/26647-STV-Olblasty.cs
+++ b/Quest Behaviors/SpecificQuests/26647-STV-Olblasty.cs
@@ -142,8 +142,6 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.Olblasty
                         new PrioritySelector(
                             new Decorator(ctx => Me.Mounted,
                                 new ActionRunCoroutine(context => CommonCoroutines.Dismount("Getting in vehicle"))),
-                            new Decorator(ctx => Me.IsShapeshifted(),
-                                new Action(ctx => Lua.DoString("CancelShapeshiftForm()"))),
                             new Action(ctx => vehicle.Interact())))));
         }
 

--- a/Quest Behaviors/SpecificQuests/27738-Uldum-ThePitOfScales.cs
+++ b/Quest Behaviors/SpecificQuests/27738-Uldum-ThePitOfScales.cs
@@ -424,7 +424,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.ThePitOfScales
                             QBCLog.Info("Finished");
                         })),
 
-                    new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
+                    new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
 
                     // If Young Crocolisks are attacking, jump up and down...
                     // NB: If we started jumping during combat, we might need to turn it off

--- a/Quest Behaviors/SpecificQuests/27990-Uldum-Battlezone.cs
+++ b/Quest Behaviors/SpecificQuests/27990-Uldum-Battlezone.cs
@@ -315,7 +315,7 @@ namespace Honorbuddy.Quest_Behaviors.Uldum.Battlezone_24910
                 new Decorator(context => Me.IsMoving,
                     new Action(context => { Navigator.PlayerMover.MoveStop(); })),
                 new Decorator(context => Me.Mounted,
-                    new ActionRunCoroutine(context => UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.DismountOrCancelShapeshift))),
+                    new ActionRunCoroutine(context => UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.Dismount))),
                 new ActionFail(context =>
                 {
                     // If we got booted out of a vehicle for some reason, reset the weapons...

--- a/Quest Behaviors/SpecificQuests/30973-TownlongSteppes-UpInFlames.cs
+++ b/Quest Behaviors/SpecificQuests/30973-TownlongSteppes-UpInFlames.cs
@@ -1003,7 +1003,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UpInFlames
 
                                 new Decorator(context => !Navigator.AtLocation(SelectedKegBombAimPosition),
                                     new Action(context => { Navigator.MoveTo(SelectedKegBombAimPosition); })),
-                                new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
+                                new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
                                 new Decorator(context => Me.IsMoving,
                                     new Action(context => { WoWMovement.MoveStop(); })),
                                 new Decorator(context => !Me.IsFacing(SelectedKegBomb),

--- a/Quest Behaviors/SpecificQuests/DeathknightStart/AnEndToAllThings.cs
+++ b/Quest Behaviors/SpecificQuests/DeathknightStart/AnEndToAllThings.cs
@@ -265,7 +265,7 @@ namespace Honorbuddy.Quest_Behaviors.DeathknightStart.AnEndToAllThings
 
                 // If we're mounted on something other than the dragon, then dismount...
                 new Decorator(context => Me.Mounted && !Query.IsViable(DragonVehicle),
-                    new ActionRunCoroutine(context => UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.DismountOrCancelShapeshift))),
+                    new ActionRunCoroutine(context => UtilityCoroutine.ExecuteMountStrategy(MountStrategyType.Dismount))),
 
                 // If we're on the dragon, get moving...
                 new Decorator(context => Query.IsViable(DragonVehicle),

--- a/Quest Behaviors/SpecificQuests/DeathknightStart/WaitForPatrol.cs
+++ b/Quest Behaviors/SpecificQuests/DeathknightStart/WaitForPatrol.cs
@@ -458,7 +458,7 @@ namespace Honorbuddy.Quest_Behaviors.DeathknightStart.WaitForPatrol
                             MovementBy))),
 
                  // Dismount once we've arrived at mob or destination...
-                 new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
+                 new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount())),
 
                 new Decorator(ctx => StyxWoW.Me.IsMoving, new Action(ctx => WoWMovement.MoveStop())),
 

--- a/Quest Behaviors/TaxiRide.cs
+++ b/Quest Behaviors/TaxiRide.cs
@@ -190,7 +190,7 @@ namespace Styx.Bot.Quest_Behaviors.TaxiRide
                         )
                     ),
 
-                    new Decorator(ctx => Me.IsMounted(), new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount("Interact Flightmaster"))),
+                    new Decorator(ctx => Me.Mounted, new ActionRunCoroutine(ctx => CommonCoroutines.LandAndDismount("Interact Flightmaster"))),
 
                     new Decorator(ret => !CurrentNpc.WithinInteractRange,
                         new Action(ret => Navigator.MoveTo(CurrentNpc.Location))
@@ -202,10 +202,6 @@ namespace Styx.Bot.Quest_Behaviors.TaxiRide
                             new DecoratorContinue(ret => WoWMovement.ActiveMover.IsMoving,
                                 new Sequence(
                                     new Action(ret => WoWMovement.MoveStop()),
-                                    new SleepForLagDuration())),
-                            new DecoratorContinue(ret => Me.IsShapeshifted(),
-                                new Sequence(
-                                    new Action(ret => Lua.DoString("CancelShapeshiftForm()")),
                                     new SleepForLagDuration())),
                             new Action(ret => CurrentNpc.Interact()),
                             new Sleep(1000),


### PR DESCRIPTION
We do not need shapeshifting logic anymore as HB3 mounting takes all of
this into account, so get rid of the things related to this.

Also improve mounting logic to switch mounts when we are on a ground
mount, but a flying mount is requested.
