### PR TITLE
BornToShred QB fix

### DIFF
--- a/Quest Behaviors/SpecificQuests/33729-Talador-HordeBorntoShred.cs
+++ b/Quest Behaviors/SpecificQuests/33729-Talador-HordeBorntoShred.cs
@@ -132,7 +132,10 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.HordeBorntoShred
             get
             {
                 return ObjectManager.GetObjectsOfType<WoWUnit>()
-                    .FirstOrDefault(r => r.NpcFlags == 1 && r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
+                    // http://www.wowhead.com/npc=75721 - Unmounted Shredder
+                    // http://www.wowhead.com/npc=75942 - Mounted Shredder
+                    // Shredder 75721 despawns when interacted with and player is mounted on top of a newly spanwned Shredder with ID 75942
+                    .FirstOrDefault(r => r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
             }
         }
 

--- a/Quest Behaviors/SpecificQuests/34097-Talador-AllianceBorntoShred.cs
+++ b/Quest Behaviors/SpecificQuests/34097-Talador-AllianceBorntoShred.cs
@@ -110,7 +110,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AllianceBorntoShred
             {
                 var myLoc = Me.Location;
                 return (from u in ObjectManager.GetObjectsOfType<WoWUnit>()
-                        where MobIds.Contains(u.Entry) && !u.IsDead 
+                        where MobIds.Contains(u.Entry) && !u.IsDead
                         let loc = u.Location
                         orderby loc.DistanceSquared(myLoc)
                         select u).ToList();
@@ -139,7 +139,10 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AllianceBorntoShred
             get
             {
                 return ObjectManager.GetObjectsOfType<WoWUnit>()
-                    .FirstOrDefault(r => r.NpcFlags == 1 && r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
+                    // http://www.wowhead.com/npc=75721 - Unmounted Shreader
+                    // http://www.wowhead.com/npc=75942 - Mounted Shreader
+                    // Shredder 75721 despawns when interacted with and player is mounted on top of a newly spanwned Shredder with ID 75942
+                    .FirstOrDefault(r => r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
             }
         }
 


### PR DESCRIPTION
* Fixed a bug in BornToShred that caused it to fail to mount the shredder because its WoWUnit query found no matches. The NpcFlags test was unnecessary.