### PR TITLE
Fix alive check in DoWhen

### DIFF
--- a/Quest Behaviors/Hooks/DoWhen.cs
+++ b/Quest Behaviors/Hooks/DoWhen.cs
@@ -470,7 +470,7 @@ namespace Honorbuddy.Quest_Behaviors.DoWhen
         private async Task<bool> MainCoroutine()
         {
             // Ignore, while in non-actionable condition...
-            if (Me.IsDead && !AllowExecutionWhileNotAlive)
+            if (!Me.IsAlive && !AllowExecutionWhileNotAlive)
                 return false;
 
             // Ignore if eating or drinking...


### PR DESCRIPTION
This was using the wrong check causing DoWhens to run while the player
was a ghost.