### PR TITLE
Added a 'VariantQuestIds' to QuestBehaviorBase

### DIFF
--- a/Quest Behaviors/CombatUseItemOnV2.cs
+++ b/Quest Behaviors/CombatUseItemOnV2.cs
@@ -360,7 +360,7 @@ namespace Honorbuddy.Quest_Behaviors.CombatUseItemOnV2
                     && (!ItemUseAlwaysSucceeds)
                     && ((UseItemStrategy == UseItemStrategyType.UseItemOncePerTarget)
                         || (UseItemStrategy == UseItemStrategyType.UseItemOncePerTargetDontDefend)
-                        || (QuestId <= 0))),
+                        || (!VariantQuestIds.Any()))),
                 context => string.Format("For a UseItemStrategy of {0}, ItemAppliesAuraId must be specified",
                                         UseItemStrategy));
         }
@@ -595,7 +595,7 @@ namespace Honorbuddy.Quest_Behaviors.CombatUseItemOnV2
                                 if (ItemUseAlwaysSucceeds || SelectedTarget.HasAura(ItemAppliesAuraId))
                                 {
                                     // Count our success if no associated quest...
-                                    if (QuestId == 0)
+                                    if (!VariantQuestIds.Any())
                                     { ++Counter; }
 
                                     // If we can only use the item once per target, blacklist this target from subsequent selection...

--- a/Quest Behaviors/EscortGroup.cs
+++ b/Quest Behaviors/EscortGroup.cs
@@ -495,7 +495,7 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
 
                 BehaviorState = BehaviorStateType.InitialState;
 
-                this.UpdateGoalText(QuestId, "Looting and Harvesting are disabled while Escort in progress");
+                this.UpdateGoalText(GetQuestOrVariantId(), "Looting and Harvesting are disabled while Escort in progress");
             }
         }
 
@@ -1022,18 +1022,18 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
 
                 case EscortCompleteWhenType.QuestComplete:
                     {
-                        var quest = Me.QuestLog.GetQuestById((uint)QuestId);
+                        var quest = GetQuestOrVariantInLog();
                         return (quest == null) || quest.IsCompleted;
                     }
 
                 case EscortCompleteWhenType.QuestCompleteOrFails:
                     {
-                        var quest = Me.QuestLog.GetQuestById((uint)QuestId);
+                        var quest = GetQuestOrVariantInLog();
                         return (quest == null) || quest.IsCompleted || IsEscortFailed(escortedUnits);
                     }
 
                 case EscortCompleteWhenType.QuestObjectiveComplete:
-                    return Me.IsQuestObjectiveComplete(QuestId, QuestObjectiveIndex);
+                    return Me.IsQuestObjectiveComplete((int)(GetQuestOrVariantInLog()?.Id ?? 0), QuestObjectiveIndex);
             }
 
             QBCLog.MaintenanceError("EscortCompleteWhen({0}) state is unhandled", EscortCompleteWhen);
@@ -1049,7 +1049,7 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
 
             if (QuestId > 0)
             {
-                PlayerQuest quest = Me.QuestLog.GetQuestById((uint)QuestId);
+                PlayerQuest quest = GetQuestOrVariantInLog();
                 isFailed |= quest.IsFailed;
             }
 

--- a/Quest Behaviors/EscortGroup.cs
+++ b/Quest Behaviors/EscortGroup.cs
@@ -318,20 +318,20 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
                     IsAttributeProblem = true;
                 }
 
-                if ((EscortCompleteWhen == EscortCompleteWhenType.QuestComplete) && (QuestId == 0))
+                if ((EscortCompleteWhen == EscortCompleteWhenType.QuestComplete) && (!VariantQuestIds.Any()))
                 {
                     QBCLog.Error("With a EscortCompleteWhen argument of QuestComplete, you must specify a QuestId argument");
                     IsAttributeProblem = true;
                 }
 
-                if ((QuestId == 0) && (EscortCompleteWhen != EscortCompleteWhenType.DestinationReached))
+                if ((!VariantQuestIds.Any()) && (EscortCompleteWhen != EscortCompleteWhenType.DestinationReached))
                 {
                     QBCLog.Error("When no QuestId is specified, EscortCompleteWhen must be DestinationReached");
                     IsAttributeProblem = true;
                 }
 
                 if ((EscortCompleteWhen == EscortCompleteWhenType.QuestObjectiveComplete)
-                    && ((QuestId == 0) || (QuestObjectiveIndex == 0)))
+                    && ((!VariantQuestIds.Any()) || (QuestObjectiveIndex == 0)))
                 {
                     QBCLog.Error("With an EscortCompleteWhen argument of QuestObjectiveComplete, you must specify both QuestId and QuestObjectiveIndex arguments");
                     IsAttributeProblem = true;
@@ -495,7 +495,7 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
 
                 BehaviorState = BehaviorStateType.InitialState;
 
-                this.UpdateGoalText(GetQuestOrVariantId(), "Looting and Harvesting are disabled while Escort in progress");
+                this.UpdateGoalText(GetQuestId(), "Looting and Harvesting are disabled while Escort in progress");
             }
         }
 
@@ -1022,18 +1022,18 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
 
                 case EscortCompleteWhenType.QuestComplete:
                     {
-                        var quest = GetQuestOrVariantInLog();
+                        var quest = GetQuestInLog();
                         return (quest == null) || quest.IsCompleted;
                     }
 
                 case EscortCompleteWhenType.QuestCompleteOrFails:
                     {
-                        var quest = GetQuestOrVariantInLog();
+                        var quest = GetQuestInLog();
                         return (quest == null) || quest.IsCompleted || IsEscortFailed(escortedUnits);
                     }
 
                 case EscortCompleteWhenType.QuestObjectiveComplete:
-                    return Me.IsQuestObjectiveComplete(GetQuestOrVariantId(), QuestObjectiveIndex);
+                    return Me.IsQuestObjectiveComplete(GetQuestId(), QuestObjectiveIndex);
             }
 
             QBCLog.MaintenanceError("EscortCompleteWhen({0}) state is unhandled", EscortCompleteWhen);
@@ -1047,9 +1047,9 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
         {
             bool isFailed = !IsEscortedGroupViable(escortedUnits);
 
-            if (QuestId > 0)
+            if (VariantQuestIds.Any())
             {
-                PlayerQuest quest = GetQuestOrVariantInLog();
+                PlayerQuest quest = GetQuestInLog();
                 isFailed |= quest.IsFailed;
             }
 

--- a/Quest Behaviors/EscortGroup.cs
+++ b/Quest Behaviors/EscortGroup.cs
@@ -1033,7 +1033,7 @@ namespace Honorbuddy.Quest_Behaviors.EscortGroup
                     }
 
                 case EscortCompleteWhenType.QuestObjectiveComplete:
-                    return Me.IsQuestObjectiveComplete((int)(GetQuestOrVariantInLog()?.Id ?? 0), QuestObjectiveIndex);
+                    return Me.IsQuestObjectiveComplete(GetQuestOrVariantId(), QuestObjectiveIndex);
             }
 
             QBCLog.MaintenanceError("EscortCompleteWhen({0}) state is unhandled", EscortCompleteWhen);

--- a/Quest Behaviors/FlyTo.cs
+++ b/Quest Behaviors/FlyTo.cs
@@ -334,7 +334,7 @@ namespace Honorbuddy.Quest_Behaviors.FlyTo
                 RoughDestination = PotentialDestinations.CurrentWaypoint();
 
                 var actionDescription = $"Flying to '{RoughDestination.Name}' ({RoughDestination.Location})";
-                this.UpdateGoalText(GetQuestOrVariantId(), actionDescription);
+                this.UpdateGoalText(GetQuestId(), actionDescription);
                 TreeRoot.StatusText = actionDescription;
             }
         }

--- a/Quest Behaviors/FlyTo.cs
+++ b/Quest Behaviors/FlyTo.cs
@@ -333,8 +333,8 @@ namespace Honorbuddy.Quest_Behaviors.FlyTo
                 PotentialDestinations.WaypointVisitStrategy = HuntingGroundsType.WaypointVisitStrategyType.PickOneAtRandom;
                 RoughDestination = PotentialDestinations.CurrentWaypoint();
 
-                var actionDescription = string.Format("Flying to '{0}' ({1})", RoughDestination.Name, RoughDestination.Location);
-                this.UpdateGoalText(QuestId, actionDescription);
+                var actionDescription = $"Flying to '{RoughDestination.Name}' ({RoughDestination.Location})";
+                this.UpdateGoalText(GetQuestOrVariantId(), actionDescription);
                 TreeRoot.StatusText = actionDescription;
             }
         }

--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -916,7 +916,7 @@ namespace Honorbuddy.Quest_Behaviors.InteractWith
                     CloseOpenFrames();
                     Me.ClearTarget();
 
-                    this.UpdateGoalText(QuestId, GetGoalText());
+                    this.UpdateGoalText(GetQuestOrVariantId(), GetGoalText());
                     InteractAttemptCount = 0;
                     _watchdogTimerToReachDestination = null;
                 }

--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -916,7 +916,7 @@ namespace Honorbuddy.Quest_Behaviors.InteractWith
                     CloseOpenFrames();
                     Me.ClearTarget();
 
-                    this.UpdateGoalText(GetQuestOrVariantId(), GetGoalText());
+                    this.UpdateGoalText(GetQuestId(), GetGoalText());
                     InteractAttemptCount = 0;
                     _watchdogTimerToReachDestination = null;
                 }

--- a/Quest Behaviors/Misc/BreakImmunityByKillingMobsInCloseProximity.cs
+++ b/Quest Behaviors/Misc/BreakImmunityByKillingMobsInCloseProximity.cs
@@ -210,7 +210,7 @@ namespace Honorbuddy.Quest_Behaviors.BreakImmunityByKillingMobsInCloseProximity
                 return true;
             }
 
-            if (SelectedNpc.IsDead && SelectedNpc.TaggedByMe && QuestId == 0)
+            if (SelectedNpc.IsDead && SelectedNpc.TaggedByMe && GetQuestId() == 0)
             {
                 BehaviorDone();
                 return true;

--- a/Quest Behaviors/Misc/RunLua.cs
+++ b/Quest Behaviors/Misc/RunLua.cs
@@ -150,7 +150,7 @@ namespace Honorbuddy.Quest_Behaviors.RunLua
             // So we don't want to falsely inform the user of things that will be skipped.
             if (isBehaviorShouldRun)
             {
-                this.UpdateGoalText(QuestId);
+                this.UpdateGoalText(GetQuestOrVariantId());
                 TreeRoot.StatusText = string.Format("{0}: {1} {2} number of times while waiting {3} inbetween",
                                                     GetType().Name, LuaCommand, NumOfTimes, WaitTime);
 

--- a/Quest Behaviors/Misc/RunLua.cs
+++ b/Quest Behaviors/Misc/RunLua.cs
@@ -150,7 +150,7 @@ namespace Honorbuddy.Quest_Behaviors.RunLua
             // So we don't want to falsely inform the user of things that will be skipped.
             if (isBehaviorShouldRun)
             {
-                this.UpdateGoalText(GetQuestOrVariantId());
+                this.UpdateGoalText(GetQuestId());
                 TreeRoot.StatusText = string.Format("{0}: {1} {2} number of times while waiting {3} inbetween",
                                                     GetType().Name, LuaCommand, NumOfTimes, WaitTime);
 

--- a/Quest Behaviors/MrFishIt.cs
+++ b/Quest Behaviors/MrFishIt.cs
@@ -303,13 +303,13 @@ namespace Honorbuddy.Quest_Behaviors.MrFishIt
                 // Make sure we don't get logged out
                 GlobalSettings.Instance.LogoutForInactivity = false;
 
-                PlayerQuest quest = GetQuestOrVariantInLog();
+                PlayerQuest quest = GetQuestInLog();
                 if (quest == null)
-                    this.UpdateGoalText(QuestId, "Fishing Item [" + CollectItemId + "]");
+                    this.UpdateGoalText(GetQuestId(), "Fishing Item [" + CollectItemId + "]");
                 else
                     this.UpdateGoalText((int)quest.Id, "Fishing Item for [" + quest.Name + "]");
 
-                QBCLog.DeveloperInfo("Fishing Item (for QuestId {0}): {1}({2}) x{3}", quest?.Id ?? (uint)QuestId, Utility.GetItemNameFromId(CollectItemId), CollectItemId, CollectItemCount.Value);
+                QBCLog.DeveloperInfo("Fishing Item (for QuestId {0}): {1}({2}) x{3}", quest?.Id ?? (uint)GetQuestId(), Utility.GetItemNameFromId(CollectItemId), CollectItemId, CollectItemCount.Value);
 
                 if (UseFishingGear)
                 {

--- a/Quest Behaviors/MrFishIt.cs
+++ b/Quest Behaviors/MrFishIt.cs
@@ -303,13 +303,13 @@ namespace Honorbuddy.Quest_Behaviors.MrFishIt
                 // Make sure we don't get logged out
                 GlobalSettings.Instance.LogoutForInactivity = false;
 
-                PlayerQuest quest = StyxWoW.Me.QuestLog.GetQuestById((uint)QuestId);
+                PlayerQuest quest = GetQuestOrVariantInLog();
                 if (quest == null)
                     this.UpdateGoalText(QuestId, "Fishing Item [" + CollectItemId + "]");
                 else
-                    this.UpdateGoalText(QuestId, "Fishing Item for [" + quest.Name + "]");
+                    this.UpdateGoalText((int)quest.Id, "Fishing Item for [" + quest.Name + "]");
 
-                QBCLog.DeveloperInfo("Fishing Item (for QuestId {0}): {1}({2}) x{3}", QuestId, Utility.GetItemNameFromId(CollectItemId), CollectItemId, CollectItemCount.Value);
+                QBCLog.DeveloperInfo("Fishing Item (for QuestId {0}): {1}({2}) x{3}", quest?.Id ?? (uint)QuestId, Utility.GetItemNameFromId(CollectItemId), CollectItemId, CollectItemCount.Value);
 
                 if (UseFishingGear)
                 {

--- a/Quest Behaviors/MrFishIt.cs
+++ b/Quest Behaviors/MrFishIt.cs
@@ -300,13 +300,13 @@ namespace Honorbuddy.Quest_Behaviors.MrFishIt
                 // Make sure we don't get logged out
                 GlobalSettings.Instance.LogoutForInactivity = false;
 
-                PlayerQuest quest = StyxWoW.Me.QuestLog.GetQuestById((uint)QuestId);
+                PlayerQuest quest = GetQuestOrVariantInLog();
                 if (quest == null)
                     this.UpdateGoalText(QuestId, "Fishing Item [" + CollectItemId + "]");
                 else
-                    this.UpdateGoalText(QuestId, "Fishing Item for [" + quest.Name + "]");
+                    this.UpdateGoalText((int)quest.Id, "Fishing Item for [" + quest.Name + "]");
 
-                QBCLog.DeveloperInfo("Fishing Item (for QuestId {0}): {1}({2}) x{3}", QuestId, Utility.GetItemNameFromId(CollectItemId), CollectItemId, CollectItemCount.Value);
+                QBCLog.DeveloperInfo("Fishing Item (for QuestId {0}): {1}({2}) x{3}", quest?.Id ?? (uint)QuestId, Utility.GetItemNameFromId(CollectItemId), CollectItemId, CollectItemCount.Value);
 
                 if (UseFishingGear)
                 {

--- a/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
+++ b/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
@@ -718,8 +718,6 @@ namespace Honorbuddy.QuestBehaviorCore
 
         protected PlayerQuest GetQuestOrVariantInLog()
         {
-            if (QuestId <= 0)
-                return null;
             if (VariantQuestIds.Any())
                 return VariantQuestIds.Select(id => StyxWoW.Me.QuestLog.GetQuestById((uint)id)).FirstOrDefault(q => q != null);
 

--- a/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
+++ b/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
@@ -564,7 +564,7 @@ namespace Honorbuddy.QuestBehaviorCore
                 context => "Cannot provide both a QuestId and VariantQuestIds at same time.");
 
             UsageCheck_SemanticCoherency(Element,
-                VariantQuestIds.Length < 2,
+                VariantQuestIds.Length == 1,
                 context => "VariantQuestIds must provide at least 2 quest IDs.");
 
             if (VariantQuestIds.Any())

--- a/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
+++ b/Quest Behaviors/QuestBehaviorCore/QuestBehaviorBase.cs
@@ -567,16 +567,6 @@ namespace Honorbuddy.QuestBehaviorCore
                 VariantQuestIds.Length == 1,
                 context => "VariantQuestIds must provide at least 2 quest IDs.");
 
-            if (VariantQuestIds.Any())
-            {
-                var completedQuests = new HashSet<uint>(StyxWoW.Me.QuestLog.GetCompletedQuests());
-                UsageCheck_SemanticCoherency(Element,
-                    VariantQuestIds.Count(id => Me.QuestLog.ContainsQuest((uint)id) || completedQuests.Contains((uint)id)) > 1,
-                    context => $"Multiple quests provided by VariantQuestIds: ({string.Join(", ", VariantQuestIds)}) " +
-                               "were found in player's quest log or have been turned in. " +
-                               "This indicates that some/all of the quests specified by VariantQuestIds are not variants.");
-            }
-
             EvaluateUsage_SemanticCoherency(Element);
 
             // Deprecated attributes...

--- a/Quest Behaviors/RunMacro.cs
+++ b/Quest Behaviors/RunMacro.cs
@@ -91,7 +91,7 @@ namespace Honorbuddy.Quest_Behaviors.RunMacro
             // constructor call.
             OnStart_HandleAttributeProblem();
 
-            this.UpdateGoalText(QuestId, GoalText);
+            this.UpdateGoalText(GetQuestOrVariantId(), GoalText);
         }
 
         protected override void EvaluateUsage_DeprecatedAttributes(XElement xElement)
@@ -131,7 +131,7 @@ namespace Honorbuddy.Quest_Behaviors.RunMacro
 
             for (int counter = 1; counter <= NumOfTimes; ++counter)
             {
-                this.UpdateGoalText(QuestId, string.Format("Running macro {0} times", NumOfTimes));
+                this.UpdateGoalText(GetQuestOrVariantId(), string.Format("Running macro {0} times", NumOfTimes));
                 TreeRoot.StatusText = string.Format("RunMacro {0}/{1} Times", counter, NumOfTimes);
 
                 Lua.DoString(string.Format("RunMacroText(\"{0}\")", Macro), 0);

--- a/Quest Behaviors/RunMacro.cs
+++ b/Quest Behaviors/RunMacro.cs
@@ -91,7 +91,7 @@ namespace Honorbuddy.Quest_Behaviors.RunMacro
             // constructor call.
             OnStart_HandleAttributeProblem();
 
-            this.UpdateGoalText(GetQuestOrVariantId(), GoalText);
+            this.UpdateGoalText(GetQuestId(), GoalText);
         }
 
         protected override void EvaluateUsage_DeprecatedAttributes(XElement xElement)
@@ -131,7 +131,7 @@ namespace Honorbuddy.Quest_Behaviors.RunMacro
 
             for (int counter = 1; counter <= NumOfTimes; ++counter)
             {
-                this.UpdateGoalText(GetQuestOrVariantId(), string.Format("Running macro {0} times", NumOfTimes));
+                this.UpdateGoalText(GetQuestId(), string.Format("Running macro {0} times", NumOfTimes));
                 TreeRoot.StatusText = string.Format("RunMacro {0}/{1} Times", counter, NumOfTimes);
 
                 Lua.DoString(string.Format("RunMacroText(\"{0}\")", Macro), 0);

--- a/Quest Behaviors/SpecificQuests/10129-10146-Hellfire-MurkethAndShaadraz.cs
+++ b/Quest Behaviors/SpecificQuests/10129-10146-Hellfire-MurkethAndShaadraz.cs
@@ -250,7 +250,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.MurkethAndShaadraz
                 var questObjectiveIndex = questObjectiveIndexDelegate(context);
                 var mobId = mobIdDelegate(context);
 
-                if (Me.IsQuestObjectiveComplete(QuestId, questObjectiveIndex))
+                if (Me.IsQuestObjectiveComplete(GetQuestOrVariantId(), questObjectiveIndex))
                 { return false; }
 
                 SelectedTarget = ObjectManager.ObjectList.FirstOrDefault(o => o.Entry == mobId);

--- a/Quest Behaviors/SpecificQuests/10129-10146-Hellfire-MurkethAndShaadraz.cs
+++ b/Quest Behaviors/SpecificQuests/10129-10146-Hellfire-MurkethAndShaadraz.cs
@@ -250,7 +250,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.MurkethAndShaadraz
                 var questObjectiveIndex = questObjectiveIndexDelegate(context);
                 var mobId = mobIdDelegate(context);
 
-                if (Me.IsQuestObjectiveComplete(GetQuestOrVariantId(), questObjectiveIndex))
+                if (Me.IsQuestObjectiveComplete(GetQuestId(), questObjectiveIndex))
                 { return false; }
 
                 SelectedTarget = ObjectManager.ObjectList.FirstOrDefault(o => o.Entry == mobId);

--- a/Quest Behaviors/SpecificQuests/10162-10163-Hellfire-MissionTheAbyssalShelf.cs
+++ b/Quest Behaviors/SpecificQuests/10162-10163-Hellfire-MissionTheAbyssalShelf.cs
@@ -255,7 +255,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.MissionTheAbyssalShelf
                     var questObjectiveIndex = questObjectiveIndexDelegate(context);
                     var mobId = mobIdDelegate(context);
 
-                    if (Me.IsQuestObjectiveComplete(QuestId, questObjectiveIndex))
+                    if (Me.IsQuestObjectiveComplete(GetQuestOrVariantId(), questObjectiveIndex))
                     { return false; }
 
                     SelectedTarget =

--- a/Quest Behaviors/SpecificQuests/10162-10163-Hellfire-MissionTheAbyssalShelf.cs
+++ b/Quest Behaviors/SpecificQuests/10162-10163-Hellfire-MissionTheAbyssalShelf.cs
@@ -255,7 +255,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.MissionTheAbyssalShelf
                     var questObjectiveIndex = questObjectiveIndexDelegate(context);
                     var mobId = mobIdDelegate(context);
 
-                    if (Me.IsQuestObjectiveComplete(GetQuestOrVariantId(), questObjectiveIndex))
+                    if (Me.IsQuestObjectiveComplete(GetQuestId(), questObjectiveIndex))
                     { return false; }
 
                     SelectedTarget =

--- a/Quest Behaviors/SpecificQuests/14122-Kezan-TheGreatBankHeist.cs
+++ b/Quest Behaviors/SpecificQuests/14122-Kezan-TheGreatBankHeist.cs
@@ -55,7 +55,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.TheGreatBankHeist
         {
             QBCLog.BehaviorLoggingContext = this;
 
-            QuestId = 14122;
+            VariantQuestIds = new HashSet<int> {14122};
         }
 
         // DON'T EDIT THIS--it is auto-populated by Git

--- a/Quest Behaviors/SpecificQuests/24817-LostIsles-AGoblininSharksClothing.cs
+++ b/Quest Behaviors/SpecificQuests/24817-LostIsles-AGoblininSharksClothing.cs
@@ -49,7 +49,8 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AGoblininSharksClothing
         {
             QBCLog.BehaviorLoggingContext = this;
 
-            QuestId = GetAttributeAsNullable<int>("QuestId", false, ConstrainAs.QuestId(this), null) ?? 0;
+            var questId = GetAttributeAsNullable<int>("QuestId", false, ConstrainAs.QuestId(this), null) ?? 0;
+            VariantQuestIds = questId != 0 ? new HashSet<int> {questId} : new HashSet<int>();
         }
 
         // DON'T EDIT THIS--it is auto-populated by Git

--- a/Quest Behaviors/SpecificQuests/24910-Tanaris-RocketRescue.cs
+++ b/Quest Behaviors/SpecificQuests/24910-Tanaris-RocketRescue.cs
@@ -69,7 +69,7 @@ namespace Honorbuddy.Quest_Behaviors.Tanaris.RocketRescue_24910
         {
             try
             {
-                QuestId = Me.IsAlliance ? 25050 : 24910;
+                VariantQuestIds = new HashSet<int> {Me.IsAlliance ? 25050 : 24910};
                 TerminationChecksQuestProgress = false;
 
                 AuraId_EmergencyRocketPack = 75730;         // http://wowhead.com/spell=75730 (applies to us)
@@ -257,7 +257,7 @@ namespace Honorbuddy.Quest_Behaviors.Tanaris.RocketRescue_24910
 
         private async Task<bool> StateCoroutine_MountingVehicle()
         {
-            if (Me.IsQuestComplete(QuestId))
+            if (Me.IsQuestComplete(GetQuestId()))
             {
                 BehaviorDone();
                 return true;
@@ -363,7 +363,7 @@ namespace Honorbuddy.Quest_Behaviors.Tanaris.RocketRescue_24910
             }
 
             // If quest is complete, then head back...
-            if (Me.IsQuestComplete(QuestId))
+            if (Me.IsQuestComplete(GetQuestId()))
             {
                 BehaviorState = BehaviorStateType.ReturningToBase;
                 return true;
@@ -377,13 +377,14 @@ namespace Honorbuddy.Quest_Behaviors.Tanaris.RocketRescue_24910
             // Select new best target, if our current one is no longer useful...
             if (!IsViableForTargeting(SelectedTarget))
             {
-                if (!IsViableForTargeting(SelectedTarget) && !Me.IsQuestObjectiveComplete(QuestId, 1))
+                var questId = GetQuestId();
+                if (!IsViableForTargeting(SelectedTarget) && !Me.IsQuestObjectiveComplete(questId, 1))
                 {
                     SelectedTarget = FindBestTarget(MobId_Objective1_SteamwheedleSurvivor);
                     WeaponChoice = WeaponLifeRocket;
                 }
 
-                if (!IsViableForTargeting(SelectedTarget) && !Me.IsQuestObjectiveComplete(QuestId, 2))
+                if (!IsViableForTargeting(SelectedTarget) && !Me.IsQuestObjectiveComplete(questId, 2))
                 {
                     SelectedTarget = FindBestTarget(MobId_Objective2_SouthseaBlockader);
                     WeaponChoice = WeaponPirateDestroyingBomb;

--- a/Quest Behaviors/SpecificQuests/27990-Uldum-Battlezone.cs
+++ b/Quest Behaviors/SpecificQuests/27990-Uldum-Battlezone.cs
@@ -73,7 +73,7 @@ namespace Honorbuddy.Quest_Behaviors.Uldum.Battlezone_24910
         {
             try
             {
-                QuestId = 27990;
+                VariantQuestIds = new HashSet<int> {27990};
                 TerminationChecksQuestProgress = false;
 
                 MobId_Objective1_DecrepitWatcher = 47385;   // http://wowhead.com/npc=47385
@@ -244,7 +244,7 @@ namespace Honorbuddy.Quest_Behaviors.Uldum.Battlezone_24910
         private Composite StateBehaviorPS_MountingVehicle()
         {
             return new PrioritySelector(
-                new Decorator(context => Me.IsQuestComplete(QuestId),
+                new Decorator(context => Me.IsQuestComplete(GetQuestId()),
                     new Action(context => { BehaviorDone(); })),
 
                 // If we're in the vehicle, wait for the ride out to hunting grounds to complete...
@@ -362,7 +362,7 @@ namespace Honorbuddy.Quest_Behaviors.Uldum.Battlezone_24910
                     })),
 
                 // If quest is complete, then head back...
-                new Decorator(context => Me.IsQuestObjectiveComplete(QuestId, 1),
+                new Decorator(context => Me.IsQuestObjectiveComplete(GetQuestId(), 1),
                     new Action(context => { BehaviorState = BehaviorStateType.ReturningToBase; })),
 
                 new CompositeThrottle(Throttle.UserUpdate,
@@ -416,7 +416,7 @@ namespace Honorbuddy.Quest_Behaviors.Uldum.Battlezone_24910
                             "Commander Schnottz",
                             MovementBy))),
 
-                new Decorator(context => Me.IsQuestComplete(QuestId),
+                new Decorator(context => Me.IsQuestComplete(GetQuestId()),
                     new Action(context => BehaviorDone("quest complete")))
                 );
         }

--- a/Quest Behaviors/SpecificQuests/28589-HordeTwilightHighlands-EverythingButTheKitchenSink.cs
+++ b/Quest Behaviors/SpecificQuests/28589-HordeTwilightHighlands-EverythingButTheKitchenSink.cs
@@ -55,7 +55,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.EverythingButTheKitchenSink
                 // QuestRequirement* attributes are explained here...
                 //    http://www.thebuddyforum.com/mediawiki/index.php?title=Honorbuddy_Programming_Cookbook:_QuestId_for_Custom_Behaviors
                 // ...and also used for IsDone processing.
-                QuestId = 28589;
+                VariantQuestIds = new HashSet<int> { 28589};
                 QuestRequirementComplete = QuestCompleteRequirement.NotComplete;
                 QuestRequirementInLog = QuestInLogRequirement.InLog;
             }

--- a/Quest Behaviors/SpecificQuests/29663-PandaStarter-TheLessonoftheBalancedRock.cs
+++ b/Quest Behaviors/SpecificQuests/29663-PandaStarter-TheLessonoftheBalancedRock.cs
@@ -53,7 +53,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.TheLessonoftheBalancedRock
 
             try
             {
-                QuestId = 29663;
+                VariantQuestIds = new HashSet<int> { 29663 };
             }
 
             catch (Exception except)
@@ -151,7 +151,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.TheLessonoftheBalancedRock
         #region Helpers
         private Composite DoneYet()
         {
-            return new Decorator(context => Me.IsQuestComplete(QuestId),
+            return new Decorator(context => Me.IsQuestComplete(GetQuestId()),
                 new PrioritySelector(
                     // Get off pole...
                     new Decorator(context => Query.IsInVehicle(),

--- a/Quest Behaviors/SpecificQuests/29727-JadeForest-TakeNoPrisoners.cs
+++ b/Quest Behaviors/SpecificQuests/29727-JadeForest-TakeNoPrisoners.cs
@@ -66,7 +66,8 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.TakeNoPrisoners
 
             try
             {
-                QuestId = GetAttributeAsNullable("QuestId", false, ConstrainAs.QuestId(this), null) ?? 29727;
+                var questId = GetAttributeAsNullable("QuestId", false, ConstrainAs.QuestId(this), null) ?? 29727;
+                VariantQuestIds = new HashSet<int> { questId };
                 QuestRequirementComplete = GetAttributeAsNullable<QuestCompleteRequirement>("QuestCompleteRequirement", false, null, null) ?? QuestCompleteRequirement.NotComplete;
                 QuestRequirementInLog = GetAttributeAsNullable<QuestInLogRequirement>("QuestInLogRequirement", false, null, null) ?? QuestInLogRequirement.InLog;
             }

--- a/Quest Behaviors/SpecificQuests/29824-HordeJadeForest-ScoutingReportLikeJinyuInABarrel.cs
+++ b/Quest Behaviors/SpecificQuests/29824-HordeJadeForest-ScoutingReportLikeJinyuInABarrel.cs
@@ -59,7 +59,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.ScoutingReportLikeJinyuInABa
                 // QuestRequirement* attributes are explained here...
                 //    http://www.thebuddyforum.com/mediawiki/index.php?title=Honorbuddy_Programming_Cookbook:_QuestId_for_Custom_Behaviors
                 // ...and also used for IsDone processing.
-                QuestId = 29824;
+                VariantQuestIds = new HashSet<int> {29824};
                 QuestRequirementComplete = QuestCompleteRequirement.NotComplete;
                 QuestRequirementInLog = QuestInLogRequirement.InLog;
             }
@@ -213,7 +213,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.ScoutingReportLikeJinyuInABa
             if (IsDone)
                 return false;
 
-            if (Me.IsQuestComplete(QuestId) || !Query.IsInVehicle())
+            if (Me.IsQuestComplete(GetQuestId()) || !Query.IsInVehicle())
             {
                 QBCLog.Info("Finished!");
                 CharacterSettings.Instance.UseGroundMount = true;

--- a/Quest Behaviors/SpecificQuests/30231-VOEB-PompfruitPickup.cs
+++ b/Quest Behaviors/SpecificQuests/30231-VOEB-PompfruitPickup.cs
@@ -50,7 +50,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.PompfruitPickup
 
             try
             {
-                QuestId = 30231;//GetAttributeAsQuestId("QuestId", true, null) ?? 0;
+                VariantQuestIds = new HashSet<int> {30231}; //GetAttributeAsQuestId("QuestId", true, null) ?? 0;
                 QuestObjectiveIndex = 1;
             }
             catch (Exception except)

--- a/Quest Behaviors/SpecificQuests/30690-KunLai-UnmaskingTheYaungol.cs
+++ b/Quest Behaviors/SpecificQuests/30690-KunLai-UnmaskingTheYaungol.cs
@@ -222,7 +222,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UnmaskingTheYaungol
                 LevelBot.BehaviorFlags &= ~BehaviorFlags.Pull;
 
                 _combatContext = new BattlefieldContext(ItemId_BlindingRageTrap, GameObjectId_BlindingRageTrap);
-                this.UpdateGoalText(QuestId, "Looting and Harvesting are disabled while behavior in progress");
+                this.UpdateGoalText(GetQuestOrVariantId(), "Looting and Harvesting are disabled while behavior in progress");
             }
         }
 

--- a/Quest Behaviors/SpecificQuests/30690-KunLai-UnmaskingTheYaungol.cs
+++ b/Quest Behaviors/SpecificQuests/30690-KunLai-UnmaskingTheYaungol.cs
@@ -83,7 +83,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UnmaskingTheYaungol
 
             try
             {
-                QuestId = 30690; // http://wowhead.com/quest=30690
+                VariantQuestIds = new HashSet<int> {30690}; // http://wowhead.com/quest=30690
                 QuestRequirementComplete = QuestCompleteRequirement.NotComplete;
                 QuestRequirementInLog = QuestInLogRequirement.InLog;
 
@@ -184,11 +184,12 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UnmaskingTheYaungol
 
         public override void OnStart()
         {
-            PlayerQuest quest = StyxWoW.Me.QuestLog.GetQuestById((uint)QuestId);
+            var questId = GetQuestId();
+            PlayerQuest quest = StyxWoW.Me.QuestLog.GetQuestById((uint)questId);
 
-            if ((QuestId != 0) && (quest == null))
+            if ((questId != 0) && (quest == null))
             {
-                QBCLog.Error("This behavior has been associated with QuestId({0}), but the quest is not in our log", QuestId);
+                QBCLog.Error("This behavior has been associated with QuestId({0}), but the quest is not in our log", questId);
                 IsAttributeProblem = true;
             }
 
@@ -222,7 +223,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UnmaskingTheYaungol
                 LevelBot.BehaviorFlags &= ~BehaviorFlags.Pull;
 
                 _combatContext = new BattlefieldContext(ItemId_BlindingRageTrap, GameObjectId_BlindingRageTrap);
-                this.UpdateGoalText(GetQuestOrVariantId(), "Looting and Harvesting are disabled while behavior in progress");
+                this.UpdateGoalText(GetQuestId(), "Looting and Harvesting are disabled while behavior in progress");
             }
         }
 
@@ -342,7 +343,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.UnmaskingTheYaungol
                     }
                 }
 
-                if (!UtilIsProgressRequirementsMet(QuestId, QuestRequirementInLog, QuestRequirementComplete))
+                if (!UtilIsProgressRequirementsMet(GetQuestId(), QuestRequirementInLog, QuestRequirementComplete))
                 {
                     BehaviorDone("Finished");
                     return true;

--- a/Quest Behaviors/SpecificQuests/31808-DreadWastes-RampageAgainstTheMachine.cs
+++ b/Quest Behaviors/SpecificQuests/31808-DreadWastes-RampageAgainstTheMachine.cs
@@ -55,7 +55,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.RampageAgainstTheMachine
 
             try
             {
-                QuestId = 31808;//GetAttributeAsQuestId("QuestId", true, null) ?? 0;
+                VariantQuestIds = new HashSet<int> { 31808 };
             }
 
             catch (Exception except)

--- a/Quest Behaviors/SpecificQuests/33729-Talador-HordeBorntoShred.cs
+++ b/Quest Behaviors/SpecificQuests/33729-Talador-HordeBorntoShred.cs
@@ -132,7 +132,10 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.HordeBorntoShred
             get
             {
                 return ObjectManager.GetObjectsOfType<WoWUnit>()
-                    .FirstOrDefault(r => r.NpcFlags == 1 && r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
+                    // http://www.wowhead.com/npc=75721 - Unmounted Shredder
+                    // http://www.wowhead.com/npc=75942 - Mounted Shredder
+                    // Shredder 75721 despawns when interacted with and player is mounted on top of a newly spanwned Shredder with ID 75942
+                    .FirstOrDefault(r => r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
             }
         }
 

--- a/Quest Behaviors/SpecificQuests/34097-Talador-AllianceBorntoShred.cs
+++ b/Quest Behaviors/SpecificQuests/34097-Talador-AllianceBorntoShred.cs
@@ -110,7 +110,7 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AllianceBorntoShred
             {
                 var myLoc = Me.Location;
                 return (from u in ObjectManager.GetObjectsOfType<WoWUnit>()
-                        where MobIds.Contains(u.Entry) && !u.IsDead 
+                        where MobIds.Contains(u.Entry) && !u.IsDead
                         let loc = u.Location
                         orderby loc.DistanceSquared(myLoc)
                         select u).ToList();
@@ -139,7 +139,10 @@ namespace Honorbuddy.Quest_Behaviors.SpecificQuests.AllianceBorntoShred
             get
             {
                 return ObjectManager.GetObjectsOfType<WoWUnit>()
-                    .FirstOrDefault(r => r.NpcFlags == 1 && r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
+                    // http://www.wowhead.com/npc=75721 - Unmounted Shreader
+                    // http://www.wowhead.com/npc=75942 - Mounted Shreader
+                    // Shredder 75721 despawns when interacted with and player is mounted on top of a newly spanwned Shredder with ID 75942
+                    .FirstOrDefault(r => r.Entry == 75721 && r.Location.DistanceSquared(_startPoint) < 30 * 30);
             }
         }
 

--- a/Quest Behaviors/SpecificQuests/DeathknightStart/AnEndToAllThings.cs
+++ b/Quest Behaviors/SpecificQuests/DeathknightStart/AnEndToAllThings.cs
@@ -69,7 +69,7 @@ namespace Honorbuddy.Quest_Behaviors.DeathknightStart.AnEndToAllThings
         {
             try
             {
-                QuestId = 12779;
+                VariantQuestIds = new HashSet<int> { 12779 };
                 TerminationChecksQuestProgress = false;
 
                 ActionBarIndex_Attack = GetAttributeAsNullable<int>("AttackSpellIndex", true, ConstrainAs.SpellId, null) ?? 0;
@@ -260,7 +260,7 @@ namespace Honorbuddy.Quest_Behaviors.DeathknightStart.AnEndToAllThings
         private Composite StateBehaviorPS_MountingVehicle()
         {
             return new PrioritySelector(
-                new Decorator(context => Me.IsQuestComplete(QuestId),
+                new Decorator(context => Me.IsQuestComplete(GetQuestId()),
                     new Action(context => { BehaviorDone(string.Format("quest complete")); })),
 
                 // If we're mounted on something other than the dragon, then dismount...
@@ -341,7 +341,7 @@ namespace Honorbuddy.Quest_Behaviors.DeathknightStart.AnEndToAllThings
                     })),
 
                 // If quest is complete, then head back...
-                new Decorator(context => Me.IsQuestComplete(QuestId),
+                new Decorator(context => Me.IsQuestComplete(GetQuestId()),
                     new Action(context => { BehaviorState = BehaviorStateType.ReturningToBase; })),
 
                 new CompositeThrottle(Throttle.UserUpdate,
@@ -359,7 +359,7 @@ namespace Honorbuddy.Quest_Behaviors.DeathknightStart.AnEndToAllThings
                         // Try to find target...
                         new ActionFail(context =>
                         {
-                            SelectedTarget = FindMobToKill(!Me.IsQuestObjectiveComplete(QuestId, 2)
+                            SelectedTarget = FindMobToKill(!Me.IsQuestObjectiveComplete(GetQuestId(), 2)
                                                             ? MobId_ScarletBallista
                                                             : MobId_TirisfalCrusader);
                         }),

--- a/Quest Behaviors/SpecificQuests/Holiday/Brewfest-RamRidingQuests.cs
+++ b/Quest Behaviors/SpecificQuests/Holiday/Brewfest-RamRidingQuests.cs
@@ -306,7 +306,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
 
         public override void OnStart()
         {
-            var questId = GetQuestOrVariantId();
+            var questId = GetQuestId();
             if (RidingPath.Waypoints.Count <= 0)
             {
                 QBCLog.Fatal("<RidingPath> sub-element is not defined, or has no waypoints.");
@@ -340,7 +340,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
             // to zero, so the 'quest complete' logic works as expected (I.e., we're not doing the behavior
             // in a context of a quest).
             if ((questId == QuestId_BrewForBrewfest_Alliance) | (questId == QuestId_BrewForBrewfest_Horde))
-                QuestId = 0;
+                VariantQuestIds = new List<int>();
 
             // Let QuestBehaviorBase do basic initialization of the behavior, deal with bad or deprecated attributes,
             // capture configuration state, install BT hooks, etc.  This will also update the goal text.
@@ -370,7 +370,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
 
         private async Task<bool> MainCoroutine()
         {
-            var questId = GetQuestOrVariantId();
+            var questId = GetQuestId();
             var isQuestComplete = Me.IsQuestComplete(questId);
 
             // If quest is complete, we're done...
@@ -387,7 +387,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
             {
                 if (_ramReacquireStrategy == null)
                 {
-                    BehaviorDone(string.Format("Terminating: No ram re-acquire for Quest({0}) available.", GetQuestOrVariantId()));
+                    BehaviorDone(string.Format("Terminating: No ram re-acquire for Quest({0}) available.", GetQuestId()));
                     return false;
                 }
 

--- a/Quest Behaviors/SpecificQuests/Holiday/Brewfest-RamRidingQuests.cs
+++ b/Quest Behaviors/SpecificQuests/Holiday/Brewfest-RamRidingQuests.cs
@@ -306,6 +306,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
 
         public override void OnStart()
         {
+            var questId = GetQuestOrVariantId();
             if (RidingPath.Waypoints.Count <= 0)
             {
                 QBCLog.Fatal("<RidingPath> sub-element is not defined, or has no waypoints.");
@@ -321,11 +322,11 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
             }
 
             // Locate strategies for identified quest?
-            _ramReacquireStrategy = _ramReacquireStrategies.FirstOrDefault(s => s.QuestId == QuestId);
-            _ridingStrategy = _ridingStrategies.FirstOrDefault(s => s.QuestId == QuestId);
+            _ramReacquireStrategy = _ramReacquireStrategies.FirstOrDefault(s => s.QuestId == questId);
+            _ridingStrategy = _ridingStrategies.FirstOrDefault(s => s.QuestId == questId);
             if (_ridingStrategy == null)
             {
-                var message = string.Format("QuestId {0} is not supported by this behavior", QuestId);
+                var message = $"QuestId {questId} is not supported by this behavior";
                 QBCLog.Fatal(message);
                 BehaviorDone(message);
                 return;
@@ -338,7 +339,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
             // To make this work, we need to select the appropriate riding strategy (above), yet set the QuestId
             // to zero, so the 'quest complete' logic works as expected (I.e., we're not doing the behavior
             // in a context of a quest).
-            if ((QuestId == QuestId_BrewForBrewfest_Alliance) | (QuestId == QuestId_BrewForBrewfest_Horde))
+            if ((questId == QuestId_BrewForBrewfest_Alliance) | (questId == QuestId_BrewForBrewfest_Horde))
                 QuestId = 0;
 
             // Let QuestBehaviorBase do basic initialization of the behavior, deal with bad or deprecated attributes,
@@ -347,7 +348,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
             var isBehaviorShouldRun = OnStart_QuestBehaviorCore();
             if (!isBehaviorShouldRun)
             {
-                BehaviorDone(string.Format("Behavior for Quest({0}) appears complete.", QuestId));
+                BehaviorDone(string.Format("Behavior for Quest({0}) appears complete.", questId));
                 return;
             }
 
@@ -369,12 +370,13 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
 
         private async Task<bool> MainCoroutine()
         {
-            var isQuestComplete = Me.IsQuestComplete(QuestId);
+            var questId = GetQuestOrVariantId();
+            var isQuestComplete = Me.IsQuestComplete(questId);
 
             // If quest is complete, we're done...
-            if (HasQuest(QuestId) && isQuestComplete)
+            if (HasQuest(questId) && isQuestComplete)
             {
-                BehaviorDone(string.Format("Quest {0} complete.", QuestId));
+                BehaviorDone(string.Format("Quest {0} complete.", questId));
                 return false;
             }
 
@@ -385,7 +387,7 @@ namespace Honorbuddy.Quest_Behaviors.Brewfest_RamRidingQuests
             {
                 if (_ramReacquireStrategy == null)
                 {
-                    BehaviorDone(string.Format("Terminating: No ram re-acquire for Quest({0}) available.", QuestId));
+                    BehaviorDone(string.Format("Terminating: No ram re-acquire for Quest({0}) available.", GetQuestOrVariantId()));
                     return false;
                 }
 

--- a/Quest Behaviors/SpecificQuests/Holiday/HallowsEnd-CandyBuckets.cs
+++ b/Quest Behaviors/SpecificQuests/Holiday/HallowsEnd-CandyBuckets.cs
@@ -196,7 +196,7 @@ namespace Honorbuddy.Quest_Behaviors
 
             IsAttributeProblem |= s_behaviorDatabase.CandyBuckets.IsAttributeProblem;
 
-            var questId = GetQuestOrVariantId();
+            var questId = GetQuestId();
             CandyBucketInfo = s_behaviorDatabase.CandyBuckets.CandyBuckets.FirstOrDefault(qd => qd.QuestId == questId);
             if (CandyBucketInfo == null)
             {
@@ -224,7 +224,7 @@ namespace Honorbuddy.Quest_Behaviors
             if (Me.MapId != CandyBucketInfo.MapId)
             {
                 var message =
-                    $"You are on the wrong continent for Candy Bucket providing QuestId({GetQuestOrVariantId()})." +
+                    $"You are on the wrong continent for Candy Bucket providing QuestId({GetQuestId()})." +
                     $"  Please move the toon to MapId({CandyBucketInfo.MapId}) and try again.";
                 QBCLog.Fatal(message);
                 BehaviorDone(message);
@@ -235,7 +235,7 @@ namespace Honorbuddy.Quest_Behaviors
             if ((CandyBucketInfo.FactionGroup != Me.FactionGroup) && (CandyBucketInfo.FactionGroup != WoWFactionGroup.Neutral))
             {
                 var message =
-                    $"QuestId({GetQuestOrVariantId()}) is for faction group {CandyBucketInfo.FactionGroup}, your FactionGroup is {Me.FactionGroup}.";
+                    $"QuestId({GetQuestId()}) is for faction group {CandyBucketInfo.FactionGroup}, your FactionGroup is {Me.FactionGroup}.";
                 QBCLog.Fatal(message);
                 BehaviorDone(message);
                 return;
@@ -290,7 +290,7 @@ namespace Honorbuddy.Quest_Behaviors
                 return false;
 
             var isMounted = Me.Mounted;
-            var isQuestComplete = Me.IsQuestComplete(GetQuestOrVariantId());
+            var isQuestComplete = Me.IsQuestComplete(GetQuestId());
 
             // If we do the quest, we'll must do the post-quest cleanup...
             if (!isQuestComplete)

--- a/Quest Behaviors/SpecificQuests/Holiday/HallowsEnd-CandyBuckets.cs
+++ b/Quest Behaviors/SpecificQuests/Holiday/HallowsEnd-CandyBuckets.cs
@@ -196,12 +196,13 @@ namespace Honorbuddy.Quest_Behaviors
 
             IsAttributeProblem |= s_behaviorDatabase.CandyBuckets.IsAttributeProblem;
 
-            CandyBucketInfo = s_behaviorDatabase.CandyBuckets.CandyBuckets.FirstOrDefault(qd => qd.QuestId == QuestId);
+            var questId = GetQuestOrVariantId();
+            CandyBucketInfo = s_behaviorDatabase.CandyBuckets.CandyBuckets.FirstOrDefault(qd => qd.QuestId == questId);
             if (CandyBucketInfo == null)
             {
                 CandyBucketInfo = CandyBucketType.Empty;
 
-                var message = string.Format("Unable to find details for Candy Bucket providing QuestId({0})", QuestId);
+                var message = $"Unable to find details for Candy Bucket providing QuestId({questId})";
                 QBCLog.Fatal(message);
                 BehaviorDone(message);
                 return;
@@ -222,10 +223,9 @@ namespace Honorbuddy.Quest_Behaviors
             // If we're on the wrong map, we're done...
             if (Me.MapId != CandyBucketInfo.MapId)
             {
-                var message = string.Format("You are on the wrong continent for Candy Bucket providing QuestId({0})."
-                                            + "  Please move the toon to MapId({1}) and try again.",
-                                            QuestId,
-                                            CandyBucketInfo.MapId);
+                var message =
+                    $"You are on the wrong continent for Candy Bucket providing QuestId({GetQuestOrVariantId()})." +
+                    $"  Please move the toon to MapId({CandyBucketInfo.MapId}) and try again.";
                 QBCLog.Fatal(message);
                 BehaviorDone(message);
                 return;
@@ -234,10 +234,8 @@ namespace Honorbuddy.Quest_Behaviors
             // If we're the wrong faction, we're done...
             if ((CandyBucketInfo.FactionGroup != Me.FactionGroup) && (CandyBucketInfo.FactionGroup != WoWFactionGroup.Neutral))
             {
-                var message = string.Format("QuestId({0}) is for faction group {1}, your FactionGroup is {2}.",
-                                            QuestId,
-                                            CandyBucketInfo.FactionGroup,
-                                            Me.FactionGroup);
+                var message =
+                    $"QuestId({GetQuestOrVariantId()}) is for faction group {CandyBucketInfo.FactionGroup}, your FactionGroup is {Me.FactionGroup}.";
                 QBCLog.Fatal(message);
                 BehaviorDone(message);
                 return;
@@ -292,7 +290,7 @@ namespace Honorbuddy.Quest_Behaviors
                 return false;
 
             var isMounted = Me.Mounted;
-            var isQuestComplete = Me.IsQuestComplete(QuestId);
+            var isQuestComplete = Me.IsQuestComplete(GetQuestOrVariantId());
 
             // If we do the quest, we'll must do the post-quest cleanup...
             if (!isQuestComplete)

--- a/Quest Behaviors/SpecificQuests/MountHyjal/BearsUpThere.cs
+++ b/Quest Behaviors/SpecificQuests/MountHyjal/BearsUpThere.cs
@@ -68,7 +68,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
             try
             {
                 // Make certain quest is one of the ones we know how to do...
-                var questId = GetQuestOrVariantId();
+                var questId = GetQuestId();
                 if (questId == QuestId_BearsUpThere )
                     _mobId_bearTargets = MobId_Bear;
                 else if (questId == QuestId_ThoseBearsUpThere)
@@ -357,7 +357,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
 
         public bool IsClimbingTheTree { get { return Me.HasAura(AURA_CLIMBING_TREE) || Me.HasAura(AURA_CLIMBING_TREE_DAILY); } }
 
-        public bool DoWeHaveQuest => GetQuestOrVariantInLog() != null;
+        public bool DoWeHaveQuest => GetQuestInLog() != null;
 
         #region Overrides of CustomForcedBehavior
 
@@ -380,7 +380,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
 
             // is quest abandoned or complete?
             //  ..  move down until we auto-exit vehicle
-            if (!DoWeHaveQuest || Me.IsQuestComplete(GetQuestOrVariantId()))
+            if (!DoWeHaveQuest || Me.IsQuestComplete(GetQuestId()))
             {
                 await ClimbDown();
                 return true;
@@ -501,7 +501,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
                 }
                 else
                 {
-                    this.UpdateGoalText(GetQuestOrVariantId());
+                    this.UpdateGoalText(GetQuestId());
                 }
                 // Setup settings to prevent interference with your behavior --
                 // These settings will be automatically restored by QuestBehaviorBase when Dispose is called

--- a/Quest Behaviors/SpecificQuests/MountHyjal/BearsUpThere.cs
+++ b/Quest Behaviors/SpecificQuests/MountHyjal/BearsUpThere.cs
@@ -68,14 +68,15 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
             try
             {
                 // Make certain quest is one of the ones we know how to do...
-                if (QuestId == QuestId_BearsUpThere)
+                var questId = GetQuestOrVariantId();
+                if (questId == QuestId_BearsUpThere )
                     _mobId_bearTargets = MobId_Bear;
-                else if (QuestId == QuestId_ThoseBearsUpThere)
+                else if (questId == QuestId_ThoseBearsUpThere)
                     _mobId_bearTargets = MobId_DailyBear;
                 else
                 {
                     QBCLog.Fatal("This behavior can only do QuestId({0}) or QuestId({1}).  (QuestId({2}) was seen.)",
-                        QuestId_BearsUpThere, QuestId_ThoseBearsUpThere, QuestId);
+                        QuestId_BearsUpThere, QuestId_ThoseBearsUpThere, questId);
                     IsAttributeProblem = true;
                 }
                 TerminationChecksQuestProgress = false;
@@ -356,14 +357,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
 
         public bool IsClimbingTheTree { get { return Me.HasAura(AURA_CLIMBING_TREE) || Me.HasAura(AURA_CLIMBING_TREE_DAILY); } }
 
-        public bool DoWeHaveQuest
-        {
-            get
-            {
-                PlayerQuest quest = StyxWoW.Me.QuestLog.GetQuestById((uint)QuestId);
-                return quest != null;
-            }
-        }
+        public bool DoWeHaveQuest => GetQuestOrVariantInLog() != null;
 
         #region Overrides of CustomForcedBehavior
 
@@ -386,7 +380,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
 
             // is quest abandoned or complete?
             //  ..  move down until we auto-exit vehicle
-            if (!DoWeHaveQuest || Me.IsQuestComplete(QuestId))
+            if (!DoWeHaveQuest || Me.IsQuestComplete(GetQuestOrVariantId()))
             {
                 await ClimbDown();
                 return true;
@@ -507,7 +501,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
                 }
                 else
                 {
-                    this.UpdateGoalText(QuestId);
+                    this.UpdateGoalText(GetQuestOrVariantId());
                 }
                 // Setup settings to prevent interference with your behavior --
                 // These settings will be automatically restored by QuestBehaviorBase when Dispose is called

--- a/Quest Behaviors/UseTransport.cs
+++ b/Quest Behaviors/UseTransport.cs
@@ -231,7 +231,7 @@ namespace Honorbuddy.Quest_Behaviors.UseTransport
                 CharacterSettings.Instance.PullDistance = 1;
                 CharacterSettings.Instance.UseFlightPaths = false;
 
-                this.UpdateGoalText(QuestId);
+                this.UpdateGoalText(GetQuestOrVariantId());
             }
         }
         #endregion

--- a/Quest Behaviors/UseTransport.cs
+++ b/Quest Behaviors/UseTransport.cs
@@ -231,7 +231,7 @@ namespace Honorbuddy.Quest_Behaviors.UseTransport
                 CharacterSettings.Instance.PullDistance = 1;
                 CharacterSettings.Instance.UseFlightPaths = false;
 
-                this.UpdateGoalText(GetQuestOrVariantId());
+                this.UpdateGoalText(GetQuestId());
             }
         }
         #endregion

--- a/Quest Behaviors/Vehicles/FlyingVehicle.cs
+++ b/Quest Behaviors/Vehicles/FlyingVehicle.cs
@@ -204,7 +204,7 @@ namespace Honorbuddy.Quest_Behaviors.Vehicles.FlyingVehicle
             if (isBehaviorShouldRun)
             {
                 _flightTimer.Reset();
-                this.UpdateGoalText(GetQuestOrVariantId());
+                this.UpdateGoalText(GetQuestId());
             }
         }
 
@@ -426,7 +426,7 @@ namespace Honorbuddy.Quest_Behaviors.Vehicles.FlyingVehicle
 
         private PlayerQuest Quest
         {
-            get { return _quest ?? (_quest = new PerFrameCachedValue<PlayerQuest>(GetQuestOrVariantInLog)); }
+            get { return _quest ?? (_quest = new PerFrameCachedValue<PlayerQuest>(GetQuestInLog)); }
         }
 
         private PerFrameCachedValue<WoWUnit> _vehicle;

--- a/Quest Behaviors/Vehicles/FlyingVehicle.cs
+++ b/Quest Behaviors/Vehicles/FlyingVehicle.cs
@@ -204,7 +204,7 @@ namespace Honorbuddy.Quest_Behaviors.Vehicles.FlyingVehicle
             if (isBehaviorShouldRun)
             {
                 _flightTimer.Reset();
-                this.UpdateGoalText(QuestId);
+                this.UpdateGoalText(GetQuestOrVariantId());
             }
         }
 
@@ -426,7 +426,7 @@ namespace Honorbuddy.Quest_Behaviors.Vehicles.FlyingVehicle
 
         private PlayerQuest Quest
         {
-            get { return _quest ?? (_quest = new PerFrameCachedValue<PlayerQuest>(() => Me.QuestLog.GetQuestById((uint)QuestId))); }
+            get { return _quest ?? (_quest = new PerFrameCachedValue<PlayerQuest>(GetQuestOrVariantInLog)); }
         }
 
         private PerFrameCachedValue<WoWUnit> _vehicle;

--- a/Quest Behaviors/WaitTimer.cs
+++ b/Quest Behaviors/WaitTimer.cs
@@ -164,7 +164,7 @@ namespace Honorbuddy.Quest_Behaviors.WaitTimerBehavior // This prevents a confli
 
                 _timer.Reset();
 
-                this.UpdateGoalText(QuestId, "Waiting for " + _waitTimeAsString);
+                this.UpdateGoalText(GetQuestOrVariantId(), "Waiting for " + _waitTimeAsString);
             }
         }
         #endregion

--- a/Quest Behaviors/WaitTimer.cs
+++ b/Quest Behaviors/WaitTimer.cs
@@ -164,7 +164,7 @@ namespace Honorbuddy.Quest_Behaviors.WaitTimerBehavior // This prevents a confli
 
                 _timer.Reset();
 
-                this.UpdateGoalText(GetQuestOrVariantId(), "Waiting for " + _waitTimeAsString);
+                this.UpdateGoalText(GetQuestId(), "Waiting for " + _waitTimeAsString);
             }
         }
         #endregion


### PR DESCRIPTION
* Added a 'VariantQuestIds' to QuestBehaviorBase for specifying quests that are same in nature but only have a different ID. 

* Added GetQuestOrVariantInLog() and GetQuestOrVariantId() helper functions to QuestBehaviorBase

* Updated QuestBehaviorBase derived QBs to use the GetQuestOrVariantId/GetQuestOrVariantInLog helper functions as needed