### PR TITLE
BearsUpThere improvement.

### DIFF
--- a/Quest Behaviors/SpecificQuests/MountHyjal/BearsUpThere.cs
+++ b/Quest Behaviors/SpecificQuests/MountHyjal/BearsUpThere.cs
@@ -156,7 +156,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
             // bool canCast = CanCastNow(CLIMB_UP);
             Vector3 lastPos = Me.Location;
             // Lua.DoString("CastSpellByID({0})", CLIMB_UP);
-            Lua.DoString("RunMacroText(\"/click OverrideActionBarButton1\")");
+            Lua.DoString("CastPetAction(1);");
             await WaitForCurrentSpell();
             await Coroutine.Sleep(2000);
 
@@ -183,7 +183,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
                 spellId = CLIMB_DOWN_AT_TOP;
 
             Vector3 lastPos = Me.Location;
-            Lua.DoString("RunMacroText(\"/click OverrideActionBarButton2\")");
+            Lua.DoString("CastPetAction(2);");
             await WaitForCurrentSpell();
 
             // wait longer if at top due to UI skin change
@@ -288,7 +288,7 @@ namespace Honorbuddy.Quest_Behaviors.MountHyjal.BearsUpThere
             QBCLog.DeveloperInfo("(Chuck-A-Bear) threw bear at trampoline");
             // bool canCast = CanCastNow(CHUCK_A_BEAR);
             // Lua.DoString("CastSpellByID({0})", CHUCK_A_BEAR);
-            Lua.DoString("RunMacroText(\"/click OverrideActionBarButton4\")");
+            Lua.DoString("CastPetAction(4);");
             await WaitForCurrentSpell();
             await Coroutine.Sleep(4000);
         }


### PR DESCRIPTION
OverrideActionBar doesn't always show up when the player gets on the tree, causing the bot to sit idle on the tree while it spams the /click command.

This request replaces the /click with CastPetAction(); since it seems CastPetAction can handle casting the abilities no matter the situation (tested.)