### PR TITLE
InteractWith now supports the 'Land' mount strategy.

### DIFF
--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -162,7 +162,12 @@
 //              Dismount
 //                  Unmounts from an explicit mount, or cancels a 'mounted form'.  Examples
 //                  of mounted forms are Druid Flight Forms, Druid Travel Form, Shaman Ghost Wolf,
-//                  and Worgen Running Wild.
+//                  and Worgen Running Wild
+//              Land
+//                  Will make the toon land beside the mob if the toon is currently on a
+//                  flying mount and in the air. This is ideal for situations
+//                  where the interaction object can be interacted with while on a mount,
+//                  but requires you to be on the ground for the interaction to work.
 //              Mount
 //                  Mounts the mount defined in the user's preference settings.
 //              None

--- a/Quest Behaviors/QuestBehaviorCore/Types.cs
+++ b/Quest Behaviors/QuestBehaviorCore/Types.cs
@@ -107,6 +107,7 @@ namespace Honorbuddy.QuestBehaviorCore
         Dismount,
         [Obsolete("Use Dismount instead. This will be removed in the future.")]
         DismountOrCancelShapeshift,
+        Land,
         Mount,
         None,
     }

--- a/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Mount.cs
+++ b/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Mount.cs
@@ -41,20 +41,25 @@ namespace Honorbuddy.QuestBehaviorCore
         public static async Task<bool> ExecuteMountStrategy(MountStrategyType mountStrategy, NavType navType = NavType.Fly)
         {
             if (mountStrategy == MountStrategyType.None)
-            {
                 return false;
-            }
 
 #pragma warning disable 618
             // Dismount needed?
             if (mountStrategy == MountStrategyType.Dismount ||
                 mountStrategy == MountStrategyType.CancelShapeshift ||
-                mountStrategy == MountStrategyType.DismountOrCancelShapeshift)
+                mountStrategy == MountStrategyType.DismountOrCancelShapeshift ||
+                mountStrategy == MountStrategyType.Land)
             {
                 if (!Me.Mounted)
                     return false;
 
-                return await CommonCoroutines.LandAndDismount("Requested by QB");
+                if (mountStrategy != MountStrategyType.Land)
+                    return await CommonCoroutines.LandAndDismount("Requested by QB");
+
+                if (!Me.IsFlying)
+                    return false;
+
+                return await CommonCoroutines.LandAndDismount("Land requested by QB", false);
             }
 #pragma warning restore 618
 


### PR DESCRIPTION
InteractWith now supports the 'Land' PreInteractMountStrategy which will
allow the bot to land beside the interaction mob if the player is flying.  This is useful for
situations where an object can be interacted with while on a mount, but
requires you to be on the ground to do so.