### PR TITLE
Fix for the 1500ms-2000ms wait after InteractWith being interrupted.

### DIFF
--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -1090,8 +1090,12 @@ namespace Honorbuddy.Quest_Behaviors.InteractWith
 
                     // We need to wait for the lootframe if object is lootable right now,
                     // otherwise we might miss the loot frame and get stuck infinitely.
-                    if (isLootable && await Coroutine.Wait(2000, () => IsLootFrameVisible))
+                    if (isLootable && await Coroutine.Wait(2000, () => IsLootFrameVisible ||  Me.IsActuallyInCombat))
+                    {
+                      if (Me.IsActuallyInCombat)
+                          return false;
                         await SubCoroutine_HandleFrame_Loot();
+                    }
                 }
 
                 // Peg tally, if follow-up actions not expected...

--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -1091,7 +1091,11 @@ namespace Honorbuddy.Quest_Behaviors.InteractWith
                     // We need to wait for the lootframe if object is lootable right now,
                     // otherwise we might miss the loot frame and get stuck infinitely.
                     if (isLootable && await Coroutine.Wait(2000, () => IsLootFrameVisible ||  Me.IsActuallyInCombat))
-                        return await SubCoroutine_HandleFrame_Loot();
+                    {
+                      if (Me.IsActuallyInCombat)
+                          return false;
+                        await SubCoroutine_HandleFrame_Loot();
+                    }
                 }
 
                 // Peg tally, if follow-up actions not expected...

--- a/Quest Behaviors/InteractWith.cs
+++ b/Quest Behaviors/InteractWith.cs
@@ -1091,11 +1091,7 @@ namespace Honorbuddy.Quest_Behaviors.InteractWith
                     // We need to wait for the lootframe if object is lootable right now,
                     // otherwise we might miss the loot frame and get stuck infinitely.
                     if (isLootable && await Coroutine.Wait(2000, () => IsLootFrameVisible ||  Me.IsActuallyInCombat))
-                    {
-                      if (Me.IsActuallyInCombat)
-                          return false;
-                        await SubCoroutine_HandleFrame_Loot();
-                    }
+                        return await SubCoroutine_HandleFrame_Loot();
                 }
 
                 // Peg tally, if follow-up actions not expected...

--- a/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Interact.cs
+++ b/Quest Behaviors/QuestBehaviorCore/UtilityCoroutines/Interact.cs
@@ -78,7 +78,8 @@ namespace Honorbuddy.QuestBehaviorCore
                     // NB: --we want the Sequence to fail when delay completes.
                     if (castResult != SpellCastResult.LineOfSight
                         && castResult != SpellCastResult.OutOfRange
-                        && castResult != SpellCastResult.TooClose)
+                        && castResult != SpellCastResult.TooClose
+                        && castResult != SpellCastResult.Interrupted)
                     {
                         await Coroutine.Sleep(1500);
                     }


### PR DESCRIPTION
InteractWith was waiting from 1500ms to 2000ms if interrupted by combat which prevented allowing the bot to react for this duration.

This mostly caused issues for objects that have "cast bar" interaction (node harvesting, opening chests, etc) which would leave the player standing idle while being attacked by mobs or players for the 1500ms to 2000ms duration.  

This fix should allow the bot to react instantly if interrupted by combat or anything else which would cause an interruption case.